### PR TITLE
Use manual replicas on Couchbase 5.X clusters

### DIFF
--- a/app/create-index-mutation.js
+++ b/app/create-index-mutation.js
@@ -37,7 +37,8 @@ export class CreateIndexMutation extends IndexMutation {
                     `  Cond: ${this.definition.condition}`));
         }
 
-        if (this.definition.num_replica > 0) {
+        if (this.definition.num_replica > 0
+            && !this.definition.manual_replica) {
             logger.info(
                 chalk.greenBright(
                     `  Repl: ${this.definition.num_replica}`));

--- a/app/sync.js
+++ b/app/sync.js
@@ -84,12 +84,18 @@ export class Sync {
             throw new Error('Cannot define more than one primary index');
         }
 
+        if (this.manager.is4XCluster) {
+            // Force all definitions to use manual replica management
+            definitions.forEach((def) => {
+                def.manual_replica = true;
+            });
+        }
+
         const currentIndexes = await this.manager.getIndexes();
 
         let mutations = compact(flatten(
             definitions.map((definition) => Array.from(definition.getMutations(
-                currentIndexes,
-                this.manager.is4XCluster)))));
+                currentIndexes)))));
 
         if (this.options.safe) {
             mutations = mutations.filter((p) => !p.isSafe());


### PR DESCRIPTION
Motivation
----------
Automatic replica management on Couchbase 5.X still has some limitations
surrounding replica scaling, and 5.0/5.1 have limitations around replica
movement.  Some clusters may require the more granular control of
manually created replicas.

Modifications
-------------
Allow each definition to choose manual_replica mode, and leave this mode
always on for Couchbase 4.X.

Results
-------
More fine grained control of indexes on Couchbase Server 5.X, if
desired.