### PR TITLE
Add node maps to definitions

### DIFF
--- a/app/node-map.js
+++ b/app/node-map.js
@@ -1,0 +1,41 @@
+import {extend} from 'lodash';
+
+/**
+ * Stores a map of node aliases to their fully qualified name
+ */
+export class NodeMap {
+    /**
+     * @param {Object<string, string>} [hash]
+     */
+    constructor(hash) {
+        this._values = {};
+
+        if (hash) {
+            this.merge(hash);
+        }
+    }
+
+    /**
+     * Adds or overwrites mapped nodes
+     *
+     * @param {!Object<string, string>} hash
+     */
+    merge(hash) {
+        extend(this._values, hash);
+    }
+
+    /**
+     * Applies node mappings to an array of index definitions
+     *
+     * @param {Iterable.<IndexDefinition>} definition
+     */
+    apply(definition) {
+        definition.forEach((def) => {
+            if (def.nodes) {
+                def.nodes = def.nodes.map((node) => {
+                    return this._values[node] || node;
+                });
+            }
+        });
+    }
+}

--- a/example/beer-sample/default.yaml
+++ b/example/beer-sample/default.yaml
@@ -30,3 +30,8 @@ num_replica: 0
 # "this" will be the index definition
 post_process: |
   console.log(`Num replicas: ${this.num_replica}`);
+---
+type: nodeMap
+map:
+  node1: 172.21.0.2
+  node2: 172.21.0.3


### PR DESCRIPTION
Motivation
----------
Allow nodes on index definitions to be defined using aliases, which may
then be varied per environment.

Modifications
-------------
Added the nodeMap definition type.