### PR TITLE
Issue #14: Get node info from Couchbase

### DIFF
--- a/app/index-definition.js
+++ b/app/index-definition.js
@@ -39,6 +39,8 @@ import {DropIndexMutation} from './drop-index-mutation';
  * @property {array.string} index_key
  * @property {?string} condition
  * @property {?boolean} is_primary
+ * @property {?number} num_replica
+ * @property {?array.string} nodes
  */
 
 /**


### PR DESCRIPTION
Motivation
----------
Supporting node assignment updates requires information about what nodes
the index currently resides on.

Modifications
-------------
Collect and return this information as part of getIndexes in
IndexManager.

Results
-------
Node assignment information is available for use by the IndexDefinition.