### PR TITLE
Issue #14: Make cluster version available

### DIFF
--- a/app/connection-manager.js
+++ b/app/connection-manager.js
@@ -64,8 +64,7 @@ export class ConnectionManager {
             this.connectionInfo.bucketName,
             this.connectionInfo.bucketPassword);
 
-        return new IndexManager(this.connectionInfo.bucketName, this.bucket,
-            this.connectionInfo.disableRbac);
+        return new IndexManager(this.connectionInfo.bucketName, this.bucket);
     }
 
     /**

--- a/app/sync.js
+++ b/app/sync.js
@@ -86,21 +86,26 @@ export class Sync {
             throw new Error('Cannot define more than one primary index');
         }
 
-        if (this.manager.is4XCluster) {
+        // Apply the node map
+        this.nodeMap.apply(definitions);
+
+        const mutationContext = {
+            currentIndexes: await this.manager.getIndexes(),
+            clusterVersion: await this.manager.getClusterVersion(),
+        };
+
+        console.log(mutationContext.clusterVersion);
+
+        if (mutationContext.clusterVersion.major < 5) {
             // Force all definitions to use manual replica management
             definitions.forEach((def) => {
                 def.manual_replica = true;
             });
         }
 
-        // Apply the node map
-        this.nodeMap.apply(definitions);
-
-        const currentIndexes = await this.manager.getIndexes();
-
         let mutations = compact(flatten(
             definitions.map((definition) => Array.from(definition.getMutations(
-                currentIndexes)))));
+                mutationContext)))));
 
         if (this.options.safe) {
             mutations = mutations.filter((p) => !p.isSafe());


### PR DESCRIPTION
Motivation
----------
To use ALTER INDEX statements we must ensure that the cluster version is
at least 5.5.

Modifications
-------------
Use /default/pools to get the list of nodes and select the lowest
clusterCompatability to determine the effective cluster version.

Pass this value through to the index definition to determine mutations.

Also use this value instead of the --no-rbac flag to recognize we're on
a 4.0 cluster and force manual replica management.

Results
-------
Cluster version is now available for use for replica management in
future commits.

Additionally, we are now compatible with 5.0 clusters that are still
running with authentication disabled.