### PR TITLE
Issue #14: Handle pre-5.0 admin API auth

### DIFF
--- a/app/connection-manager.js
+++ b/app/connection-manager.js
@@ -64,7 +64,8 @@ export class ConnectionManager {
             this.connectionInfo.bucketName,
             this.connectionInfo.bucketPassword);
 
-        return new IndexManager(this.connectionInfo.bucketName, this.bucket);
+        return new IndexManager(this.connectionInfo.bucketName, this.bucket,
+            this.cluster);
     }
 
     /**

--- a/app/sync.js
+++ b/app/sync.js
@@ -94,8 +94,6 @@ export class Sync {
             clusterVersion: await this.manager.getClusterVersion(),
         };
 
-        console.log(mutationContext.clusterVersion);
-
         if (mutationContext.clusterVersion.major < 5) {
             // Force all definitions to use manual replica management
             definitions.forEach((def) => {


### PR DESCRIPTION
Motivation
----------
Getting index statuses is not working on pre-5.0 clusters because it
requires authentication though other operations do not.

Modifications
-------------
Use a ClusterManager instead of BucketManager for cluster level admin
API requests.

Results
-------
Admin API calls now succeed on both 4.0 and 5.0 clusters.