### PR TITLE
Issue #14: Update index node assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,15 +160,15 @@ Replicas are emulated on Couchbase Server 4.X by creating multiple indexes.  If 
 
 This approach may also be enabled on Couchbase Server 5.X by settings `manual_replica` to true on the index definition.
 
-Note that the `nodes` list is only respected during index creation, indexes will not be moved between nodes if they already exist.
+During updates, changes to the `nodes` list may result in indexes being moved from one node to another. So long as there is at least one replica this is considered a safe operation, as each replica will be moved independently leaving other replicas available to serve requests.  Changes to the order of the node list are ignored, only adding or removing nodes results in a change.
 
 ## Automatic Index Replica Management
 
-On Couchbase Server 5.X, automatic index replica managemnet is the default.  In this case, replicas are managed by Couchbase Server directly, rather than by couchbase-index-manager.
+On Couchbase Server 5.X, automatic index replica management is the default.  In this case, replicas are managed by Couchbase Server directly, rather than by couchbase-index-manager.
 
-Currently, it isn't possible to detect replicas via queries to "system:indexes".  Therefore, `num_replica` is only respected during index creation.  Changes to `num_replica` on existing indexes will be ignored.
+Note that for Couchbase Server 5.0 and 5.1, the `nodes` list is only respected during index creation. Indexes will not be moved between nodes if they already exist. Beginning with Couchbase Server 5.5 an ALTER INDEX command will be used to move replicas between nodes.
 
-Note that the `nodes` list is only respected during index creation, indexes will not be moved between nodes if they already exist.
+Because ALTER INDEX cannot currently change the number of replicas, changes to `num_replica` or the number of nodes in `nodes` is an unsafe change that will drop and recreate the index.
 
 ## Docker Image
 

--- a/app/cli.js
+++ b/app/cli.js
@@ -28,7 +28,7 @@ function parseBaseOptions(cmd) {
  */
 function handleAsync(promise) {
     promise.catch((err) => {
-        console.error(chalk.redBright(err));
+        console.error(chalk.redBright(err.stack));
 
         process.exit(1);
     });

--- a/app/feature-versions.js
+++ b/app/feature-versions.js
@@ -1,0 +1,33 @@
+ /**
+  * @typedef Version
+  * @property {number} major
+  * @property {number} minor
+  */
+
+/**
+ * Tests for compatibility with various features,
+ * given a cluster version from clusterCompatibility.
+ */
+export class FeatureVersions {
+    /**
+     * Tests for ALTER INDEX compatibility
+     *
+     * @param  {Version} version
+     * @return {boolean}
+     */
+    static alterIndex(version) {
+        return version &&
+            (version.major > 5 ||
+            (version.major == 5 && version.minor >= 5));
+    }
+
+    /**
+     * Tests for automatic replica compatibility
+     *
+     * @param  {Version} version
+     * @return {boolean}
+     */
+    static autoReplicas(version) {
+        return version && version.major >= 5;
+    }
+}

--- a/app/index-mutation.js
+++ b/app/index-mutation.js
@@ -2,6 +2,7 @@
  * Abstract base class for index mutations
  * @abstract
  *
+ * @property {number} phase Phase for this mutation, default = 1
  * @private @property {IndexDefinition} definition
  * @private @property {string} name Name of the index to mutate,
  *     may be different than the name in the definition
@@ -14,6 +15,7 @@ export class IndexMutation {
     constructor(definition, name) {
         this.definition = definition;
         this.name = name || definition.name;
+        this.phase = 1;
     }
 
     /**

--- a/app/move-index-mutation.js
+++ b/app/move-index-mutation.js
@@ -1,0 +1,57 @@
+import {IndexMutation} from './index-mutation';
+import chalk from 'chalk';
+
+/**
+ * @typedef CouchbaseIndex
+ * @property {string} name
+ * @property {array.string} index_key
+ * @property {?string} condition
+ */
+
+ /**
+ * Represents an index mutation which updates an existing index
+ */
+export class MoveIndexMutation extends IndexMutation {
+    /**
+     * @param {IndexDefinition} definition Index definition
+     * @param {string} name Name of the index to mutate
+     * @param {boolean} unsupported
+     *     If true, don't actually perform this mutation
+     */
+    constructor(definition, name, unsupported) {
+        super(definition, name);
+
+        this.unsupported = unsupported;
+    }
+
+    /** @inheritDoc */
+    print(logger) {
+        const color = this.unsupported ?
+            chalk.yellowBright :
+            chalk.cyanBright;
+
+        logger.info(color(
+            `  Move: ${this.name}`));
+
+        logger.info(color(
+            ` Nodes: ${this.definition.nodes.join()}`));
+
+        if (this.unsupported) {
+            logger.info(color(
+                `  Skip: ALTER INDEX is not supported until CB 5.5`
+            ));
+        }
+    }
+
+    /** @inheritDoc */
+    async execute(manager, logger) {
+        if (!this.unsupported) {
+            await manager.moveIndex(this.name, this.definition.nodes);
+        }
+    }
+
+    /** @inheritDoc */
+    isSafe() {
+        return true;
+    }
+}

--- a/app/sync.js
+++ b/app/sync.js
@@ -8,6 +8,7 @@ import {prompt} from 'inquirer';
 import {Plan} from './plan';
 import {IndexDefinition} from './index-definition';
 import {NodeMap} from './node-map';
+import {FeatureVersions} from './feature-versions';
 
 // Ensure that promisify is available on Node 6
 require('util.promisify').shim();
@@ -94,7 +95,7 @@ export class Sync {
             clusterVersion: await this.manager.getClusterVersion(),
         };
 
-        if (mutationContext.clusterVersion.major < 5) {
+        if (!FeatureVersions.autoReplicas(mutationContext.clusterVersion)) {
             // Force all definitions to use manual replica management
             definitions.forEach((def) => {
                 def.manual_replica = true;

--- a/app/update-index-mutation.js
+++ b/app/update-index-mutation.js
@@ -44,7 +44,8 @@ export class UpdateIndexMutation extends IndexMutation {
                     `     -> ${this.formatKeys(this.definition)}`));
         }
 
-        if (!isEqual(this.existingIndex.condition, this.definition.condition)) {
+        if (!isEqual(this.existingIndex.condition || '',
+            this.definition.condition || '')) {
             logger.info(
                 chalk.cyanBright(
                     `  Cond: ${this.existingIndex.condition || 'none'}`));
@@ -53,10 +54,17 @@ export class UpdateIndexMutation extends IndexMutation {
                     `     -> ${this.definition.condition || 'none'}`));
         }
 
-        if (this.definition.num_replica > 0) {
+        if (!this.definition.manual_replica &&
+            this.definition.num_replica > 0) {
             logger.info(
                 chalk.cyanBright(
                     `  Repl: ${this.definition.num_replica}`));
+        }
+
+        if (this.definition.nodes && this.existingIndex.nodes &&
+            !isEqual(this.definition.nodes, this.existingIndex.nodes)) {
+            logger.info(chalk.cyanBright(
+                ` Nodes: ${this.definition.nodes.join()}`));
         }
     }
 
@@ -84,6 +92,9 @@ export class UpdateIndexMutation extends IndexMutation {
 
     /** @inheritDoc */
     isSafe() {
-        return false;
+        // Safe if there are multiple replicas
+        // As each update will run in its own phase
+        return this.definition.manual_replica &&
+            this.definition.num_replica > 0;
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,15 @@
         "through2": "2.0.3"
       }
     },
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -1401,6 +1410,12 @@
       "integrity": "sha512-jWAvZu1BV8tL3pj0iosBECzzHEg+XB1zSnMjJGX83bGi/1GlGdDO7J/A0sbBBS6KJT0FVqZIzZW9C6WLiMkHpQ==",
       "dev": true
     },
+    "chai-things": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+      "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
@@ -1946,6 +1961,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "doctrine": {
@@ -3645,6 +3666,12 @@
         "number-is-nan": "1.0.1"
       }
     },
+    "is-generator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-generator/-/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
+      "dev": true
+    },
     "is-glob": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
@@ -3841,6 +3868,16 @@
         }
       }
     },
+    "jasmine-co": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jasmine-co/-/jasmine-co-1.2.2.tgz",
+      "integrity": "sha1-85rYzi3AeeD7QBr3gci74eK/uD8=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "is-generator": "1.0.3"
+      }
+    },
     "jasmine-console-reporter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jasmine-console-reporter/-/jasmine-console-reporter-3.0.0.tgz",
@@ -3974,6 +4011,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4104,6 +4147,12 @@
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -4174,6 +4223,12 @@
       "requires": {
         "chalk": "2.3.1"
       }
+    },
+    "lolex": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -4490,6 +4545,19 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.2.tgz",
+      "integrity": "sha512-KPKb+wvETBiwb4eTwtR/OsA2+iijXP+VnlSFYJo3EHjm2yjek1NWxHOUQat3i7xNLm1Bm18UA5j5Wor0yO2GtA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "just-extend": "1.1.27",
+        "lolex": "2.3.2",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      }
     },
     "node-abi": {
       "version": "2.2.0",
@@ -4827,6 +4895,15 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -5314,6 +5391,12 @@
         "ret": "0.1.15"
       }
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
@@ -5398,6 +5481,27 @@
         "unzip-response": "1.0.2",
         "xtend": "4.0.1"
       }
+    },
+    "sinon": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
+      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "2.0.0",
+        "diff": "3.5.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.2",
+        "nise": "1.3.2",
+        "supports-color": "5.2.0",
+        "type-detect": "4.0.8"
+      }
+    },
+    "sinon-chai": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.0.0.tgz",
+      "integrity": "sha512-+cqeKiuMZjZs800fRf4kjJR/Pp4p7bYY3ciZHClFNS8tSzJoAcWni/ZUZD8TrfZ+oFRyLiKWX3fTClDATGy5vQ==",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",
@@ -5909,6 +6013,12 @@
           }
         }
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-preset-env": "^1.6.1",
     "chai": "^4.1.2",
     "chai-arrays": "^2.0.0",
+    "chai-things": "^0.2.0",
     "del": "^3.0.0",
     "eslint": "^4.18.0",
     "eslint-config-google": "^0.9.1",
@@ -50,9 +51,12 @@
     "gulp-plumber": "^1.2.0",
     "gulp-sourcemaps": "^2.6.4",
     "jasmine": "^3.1.0",
+    "jasmine-co": "^1.2.2",
     "jasmine-console-reporter": "^3.0.0",
     "jasmine-core": "^3.1.0",
     "markdownlint-cli": "^0.7.1",
+    "sinon": "^4.5.0",
+    "sinon-chai": "^3.0.0",
     "source-map-support": "^0.5.4"
   },
   "dependencies": {

--- a/test/plan.spec.js
+++ b/test/plan.spec.js
@@ -1,0 +1,130 @@
+import {use, expect} from 'chai';
+import chaiArrays from 'chai-arrays';
+import chaiThings from 'chai-things';
+import sinonChai from 'sinon-chai';
+import {stub} from 'sinon';
+import {IndexDefinition} from '../app/index-definition';
+import {CreateIndexMutation} from '../app/create-index-mutation';
+import {Plan} from '../app/plan';
+
+use(chaiArrays);
+use(chaiThings);
+use(sinonChai);
+
+require('jasmine-co').install();
+
+const mockManager = {
+    buildDeferredIndexes: () => Promise.resolve(),
+    waitForIndexBuild: () => Promise.resolve(),
+};
+
+const noLogging = {
+    logger: {
+        log: () => {},
+        error: () => {},
+        warn: () => {},
+        info: () => {},
+    },
+};
+
+describe('execute', function() {
+    it('applies in order', async function() {
+        let first = new CreateIndexMutation(new IndexDefinition({
+            name: 'first',
+            index_key: 'key',
+        }));
+        let firstStub = stub(first, 'execute').returns(Promise.resolve());
+
+        let second = new CreateIndexMutation(new IndexDefinition({
+            name: 'second',
+            index_key: 'key',
+        }));
+        let secondStub = stub(second, 'execute').returns(Promise.resolve());
+
+        let plan = new Plan(mockManager, [first, second], noLogging);
+
+        await plan.execute();
+
+        expect(firstStub)
+            .to.be.calledBefore(secondStub);
+        expect(secondStub)
+            .to.be.calledOnce;
+    });
+
+    it('groups phases', async function() {
+        let first = new CreateIndexMutation(new IndexDefinition({
+            name: 'first',
+            index_key: 'key',
+        }));
+        let firstStub = stub(first, 'execute').returns(Promise.resolve());
+
+        let second = new CreateIndexMutation(new IndexDefinition({
+            name: 'second',
+            index_key: 'key',
+        }));
+        second.phase = 2;
+        let secondStub = stub(second, 'execute').returns(Promise.resolve());
+
+        let third = new CreateIndexMutation(new IndexDefinition({
+            name: 'third',
+            index_key: 'key',
+        }));
+        let thirdStub = stub(third, 'execute').returns(Promise.resolve());
+
+        let plan = new Plan(mockManager, [first, second, third], noLogging);
+
+        await plan.execute();
+
+        expect(firstStub)
+            .to.be.calledBefore(thirdStub);
+        expect(thirdStub)
+            .to.be.calledBefore(secondStub);
+        expect(secondStub)
+            .to.be.calledOnce;
+    });
+
+    it('phase failure runs rest of phase', async function() {
+        let first = new CreateIndexMutation(new IndexDefinition({
+            name: 'first',
+            index_key: 'key',
+        }));
+        stub(first, 'execute').throws();
+
+        let second = new CreateIndexMutation(new IndexDefinition({
+            name: 'second',
+            index_key: 'key',
+        }));
+        let secondStub = stub(second, 'execute').returns(Promise.resolve());
+
+        let plan = new Plan(mockManager, [first, second], noLogging);
+
+        await plan.execute()
+            .catch(() => {});
+
+        expect(secondStub)
+            .to.be.calledOnce;
+    });
+
+    it('phase failure skips subsequent phases', async function() {
+        let first = new CreateIndexMutation(new IndexDefinition({
+            name: 'first',
+            index_key: 'key',
+        }));
+        stub(first, 'execute').throws();
+
+        let second = new CreateIndexMutation(new IndexDefinition({
+            name: 'second',
+            index_key: 'key',
+        }));
+        second.phase = 2;
+        let secondStub = stub(second, 'execute').returns(Promise.resolve());
+
+        let plan = new Plan(mockManager, [first, second], noLogging);
+
+        await plan.execute()
+            .catch(() => {});
+
+        expect(secondStub)
+            .to.not.be.called;
+    });
+});


### PR DESCRIPTION
Motivation
----------
Support changes to index node assignments after an index is created.

Modifications
-------------
Implemented a phase system for mutations so that different replicas can
be moved separately to prevent downtime.

Fixed a flaw in the logic using the /indexStatus API to retrieve node
assignments for automatic replicas.

Created MoveIndexMutation to handle ALTER INDEX statements on 5.5, with
support in IndexManager.

Created a FeatureVersion class to help manage Couchbase versions where
specific features are supported.

Return proper mutations for changes to nodes and num_replicas, in both
the manual and automatic index mutation forms.

Change UpdateIndexMutation to recognize when it's actually a safe
mutation based on replicas being present.

Results
-------
Automatic replica scaling is supported on CB >= 5.0 as an unsafe
operation.

Automatic replica moving is supported on CB >= 5.5 as a safe operation,
moves are skipped with a warning on 5.0 and 5.1.

Manual replica scaling and moving is supported, and is safe so long as
there is at least one replica.

Other update operations, such as index_key and condition, are now safe
operations for any index with at least one replica and running in manual
replica mode.