### PR TITLE
Issue #21: Correct update node format for manual replicas

### DIFF
--- a/app/update-index-mutation.js
+++ b/app/update-index-mutation.js
@@ -61,10 +61,12 @@ export class UpdateIndexMutation extends IndexMutation {
                     `  Repl: ${this.definition.num_replica}`));
         }
 
-        if (this.definition.nodes && this.existingIndex.nodes &&
-            !isEqual(this.definition.nodes, this.existingIndex.nodes)) {
+        if (this.withClause.nodes && this.existingIndex.nodes &&
+            !isEqual(this.withClause.nodes, this.existingIndex.nodes)) {
             logger.info(chalk.cyanBright(
-                ` Nodes: ${this.definition.nodes.join()}`));
+                ` Nodes: ${this.existingIndex.nodes.join()}`));
+            logger.info(chalk.cyanBright(
+                `    ->: ${this.withClause.nodes.join()}`));
         }
     }
 


### PR DESCRIPTION
Motivation
----------
Updating manual replicas is showing nodes for all replicas, not just the
specific replica being updated.

Modifications
-------------
Use withClause so that the display is for the specific nodes on this
update.

Show both the current and new node assignments.

Results
-------
Information is now accurate.