### PR TITLE
Issue #24: Use Couchbase to perform index def normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ map:
 
 ## Updating Indexes
 
-It is important that couchbase-index-manager be able to recognize when indexes are updated.  Couchbase Server performs certain normalizations on both index_key and condition, meaning that the values in Couchbase may be slightly different than the values submitted when the index is created.
-
-Therefore, it is important that the definition files be created with normalization in mind.  Make sure the definitions include the already normalized version of the keys and condition, otherwise couchbase-index-manager may drop and recreate the index on each run.
+Updating existing indexes is currently an unsafe operation in most cases.  This is because the index must be dropped and recreated, so there is some period of time when the index is unavailable for queries.  The exception is if you have at least 1 replica configured and `manual_replica` is `true`.  In this case, the replicas are replaced one at a time so at least one replica is always available.
 
 ## Dropping Indexes
 

--- a/app/sync.js
+++ b/app/sync.js
@@ -102,6 +102,11 @@ export class Sync {
             });
         }
 
+        // Normalize the definitions before testing for mutations
+        for (let def of definitions) {
+            await def.normalize(this.manager);
+        }
+
         let mutations = compact(flatten(
             definitions.map((definition) => Array.from(definition.getMutations(
                 mutationContext)))));

--- a/example/beer-sample/default.yaml
+++ b/example/beer-sample/default.yaml
@@ -4,13 +4,13 @@ is_primary: true
 name: BeersByAbv
 index_key:
 - abv
-condition: (`type` = 'beer')
+condition: type = 'beer'
 num_replica: 0
 ---
 name: BeersByIbu
 index_key:
 - ibu
-condition: (`type` = 'beer')
+condition: type = 'beer'
 num_replica: 0
 ---
 name: DocsByType
@@ -19,8 +19,8 @@ index_key:
 ---
 name: BreweriesByAddress
 index_key:
-- (distinct (array `p` for `p` in `address` end))
-condition: (`type` = 'brewery')
+- distinct array p for p in address end
+condition: type = 'brewery'
 num_replica: 2
 ---
 type: override # Overrides valus set previously for this index


### PR DESCRIPTION
Motivation
----------
Reduce occurences of index updates when there aren't actually any index
changes by normalizing index_key and condition using the same approach
as Couchbase.

Modifications
-------------
Instead of normalizing as the index definition is built, normalize once
(and asynchronously) before generating mutations.

Perform normalization by using EXPLAIN to get the query plan for
creating the index and analyzing the output plan.

Results
-------
index_key and condition are now prenormalized by Couchbase before
comparing to the existing index, preventing unnecessary index updates.