### PR TITLE
Issue #25: Initial support for index partitioning

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ node_modules/
 /example
 /testbin
 /env
+
+# We can exclude because Dockerfile does the compile
+/dist

--- a/README.md
+++ b/README.md
@@ -81,17 +81,20 @@ lifecycle:
   drop: true
 ```
 
-| Field          | Required | Description |
-| -------------- |--------- | ----------- |
-| type           | N | If present, must be "index" |
-| name           | Y | Name of the index. |
-| is_primary     | N | True for a primary index. |
-| index_key      | N | Array of index keys.  May be attributes of documents deterministic functions. |
-| condition      | N | Condition for the WHERE clause of the index. |
-| manual_replica | N | Force manual replica management, rather than using Couchbase 5.X automatic replicas. Automatically set to true for Couchbase 4.X. |
-| num_replica    | N | Defaults to 0, number of index replicas to create. |
-| nodes          | N | List of nodes for index placement.  Automatic placement is used if not present. |
-| lifecycle.drop | N | If true, drops the index if it exists. |
+| Field              | Required | Description |
+| ------------------ |--------- | ----------- |
+| type               | N | If present, must be "index" |
+| name               | Y | Name of the index. |
+| is_primary         | N | True for a primary index. |
+| index_key          | N | Array of index keys.  May be attributes of documents deterministic functions. |
+| condition          | N | Condition for the WHERE clause of the index. |
+| partition          | N | For CB 5.5, object to specify index partitioning |
+| partition.exprs    | Y | Required if `partition` is present, array of strings for attributes used to create partition |
+| partition.stragegy | N | Partition strategy to use, defaults to `hash` |
+| manual_replica     | N | Force manual replica management, rather than using Couchbase 5.X automatic replicas. Automatically set to true for Couchbase 4.X. |
+| num_replica        | N | Defaults to 0, number of index replicas to create. |
+| nodes              | N | List of nodes for index placement.  Automatic placement is used if not present. |
+| lifecycle.drop     | N | If true, drops the index if it exists. |
 
 A primary index *must not* have index_key or condition properties.  A secondary index *must* have values in the index_key array.  Additionally, there may not be more than one primary index in the set of definitions.
 
@@ -103,18 +106,21 @@ When deploying to multiple environments, there may be variations in index defini
 
 Overrides are processed in the order they are found, and can only override index definitions that with the same name.  The index definition must also be found before the override.  Any field which is not supplied on the override will be skipped, leaving the original value unchanged.  The exception is `nodes` and `num_replica`, updating one will automatically adjust the other field.
 
-| Field          | Required | Description |
-| -------------- |--------- | ----------- |
-| type           | Y | Always "override". |
-| name           | Y | Name of the index. |
-| is_primary     | N | True for a primary index. |
-| index_key      | N | Array of index keys.  May be attributes of documents deterministic functions. |
-| condition      | N | Condition for the WHERE clause of the index. |
-| manual_replica | N | Force manual replica management, rather than using Couchbase 5.X automatic replicas. Automatically set to true for Couchbase 4.X. |
-| num_replica    | N | Number of index replicas to create. |
-| nodes          | N | List of nodes for index placement. |
-| lifecycle.drop | N | If true, drops the index if it exists. |
-| post_process   | N | Optional Javascript function body which may further alter the index definition. "this" will be the index definition. |
+| Field              | Required | Description |
+| ------------------ |--------- | ----------- |
+| type               | Y | Always "override". |
+| name               | Y | Name of the index. |
+| is_primary         | N | True for a primary index. |
+| index_key          | N | Array of index keys.  May be attributes of documents deterministic functions. |
+| condition          | N | Condition for the WHERE clause of the index. |
+| partition          | N | For CB 5.5, object to specify index partitioning.  Use `null` to remove partition during override. |
+| partition.exprs    | N | Array of strings for attributes used to create partition, replaces the existing array. |
+| partition.stragegy | N | Partition strategy to use |
+| manual_replica     | N | Force manual replica management, rather than using Couchbase 5.X automatic replicas. Automatically set to true for Couchbase 4.X. |
+| num_replica        | N | Number of index replicas to create. |
+| nodes              | N | List of nodes for index placement. |
+| lifecycle.drop     | N | If true, drops the index if it exists. |
+| post_process       | N | Optional Javascript function body which may further alter the index definition. "this" will be the index definition. |
 
 ## Node Maps
 

--- a/app/create-index-mutation.js
+++ b/app/create-index-mutation.js
@@ -37,6 +37,12 @@ export class CreateIndexMutation extends IndexMutation {
                     `  Cond: ${this.definition.condition}`));
         }
 
+        if (this.definition.partition) {
+            logger.info(
+                chalk.greenBright(
+                    `  Part: ${this.definition.getPartitionString()}`));
+        }
+
         if (this.definition.num_replica > 0
             && !this.definition.manual_replica) {
             logger.info(

--- a/app/feature-versions.js
+++ b/app/feature-versions.js
@@ -22,6 +22,23 @@ export class FeatureVersions {
     }
 
     /**
+     * Tests for PARTITION BY compatibility
+     *
+     * @param  {Version} version
+     * @param  {string} strategy Partition strategy, i.e. 'HASH'
+     * @return {boolean}
+     */
+    static partitionBy(version, strategy) {
+        if (strategy.toUpperCase() !== 'HASH') {
+            return false;
+        }
+
+        return version &&
+            (version.major > 5 ||
+            (version.major == 5 && version.minor >= 5));
+    }
+
+    /**
      * Tests for automatic replica compatibility
      *
      * @param  {Version} version

--- a/app/sync.js
+++ b/app/sync.js
@@ -104,6 +104,16 @@ export class Sync {
 
         // Normalize the definitions before testing for mutations
         for (let def of definitions) {
+            if (def.partition) {
+                let strategy = def.partition.strategy || 'HASH';
+
+                if (!FeatureVersions.partitionBy(
+                    mutationContext.clusterVersion, strategy)) {
+                    throw new Error(
+                        `Partition strategy '${strategy}' is not supported`);
+                }
+            }
+
             await def.normalize(this.manager);
         }
 

--- a/app/update-index-mutation.js
+++ b/app/update-index-mutation.js
@@ -44,6 +44,14 @@ export class UpdateIndexMutation extends IndexMutation {
                     `     -> ${this.formatKeys(this.definition)}`));
         }
 
+        if (!isEqual(this.existingIndex.partition || '',
+            this.definition.getPartitionString())) {
+            logger.info(chalk.cyanBright(
+                `  Part: ${this.existingIndex.partition || 'none'}`));
+            logger.info(chalk.cyanBright(
+                `     -> ${this.definition.getPartitionString() || 'none'}`));
+        }
+
         if (!isEqual(this.existingIndex.condition || '',
             this.definition.condition || '')) {
             logger.info(


### PR DESCRIPTION
Motivation
----------
Support Couchbase Server 5.5 horizontal index partitioning.

Modifications
-------------
Add `partition` attribute to the index definition hash which allows
definitions to include partition attributes and strategy.

Reject if version <5.5 or strategy != HASH (the only supported strategy
currently).

Issue update index mutations if the partition definition is changed.

Results
-------
Basic partitions without replicas are supported.  Behavior with replicas
is currently undefined and will be addressed in an upcoming commit.