### PR TITLE
Issue #27: Support for descending collation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ is_primary: true
 ---
 name: BeersByAbv
 index_key:
-- abv
+- abv DESC
 condition: (`type` = 'beer')
 num_replica: 0
 ---
@@ -86,7 +86,7 @@ lifecycle:
 | type               | N | If present, must be "index" |
 | name               | Y | Name of the index. |
 | is_primary         | N | True for a primary index. |
-| index_key          | N | Array of index keys.  May be attributes of documents deterministic functions. |
+| index_key          | N | Array of index keys.  May be attributes of documents or deterministic functions. |
 | condition          | N | Condition for the WHERE clause of the index. |
 | partition          | N | For CB 5.5, object to specify index partitioning |
 | partition.exprs    | Y | Required if `partition` is present, array of strings for attributes used to create partition |
@@ -97,6 +97,8 @@ lifecycle:
 | lifecycle.drop     | N | If true, drops the index if it exists. |
 
 A primary index *must not* have index_key or condition properties.  A secondary index *must* have values in the index_key array.  Additionally, there may not be more than one primary index in the set of definitions.
+
+For Couchbase Server 5.0 and later, you may append `DESC` to the end of an index_key to use a descending collation.
 
 If `nodes` and `num_replica` are both present, then `num_replica` must be the number of nodes minus one.
 
@@ -111,7 +113,7 @@ Overrides are processed in the order they are found, and can only override index
 | type               | Y | Always "override". |
 | name               | Y | Name of the index. |
 | is_primary         | N | True for a primary index. |
-| index_key          | N | Array of index keys.  May be attributes of documents deterministic functions. |
+| index_key          | N | Array of index keys.  May be attributes of documents or deterministic functions. |
 | condition          | N | Condition for the WHERE clause of the index. |
 | partition          | N | For CB 5.5, object to specify index partitioning.  Use `null` to remove partition during override. |
 | partition.exprs    | N | Array of strings for attributes used to create partition, replaces the existing array. |

--- a/app/index-definition.js
+++ b/app/index-definition.js
@@ -423,7 +423,8 @@ export class IndexDefinition extends IndexDefinitionBase {
                 `Invalid index definition for ${this.name}: ${e.message}`);
         }
 
-        this.index_key = (plan.keys || []).map((key) => key.expr);
+        this.index_key = (plan.keys || []).map((key) =>
+            key.expr + (key.desc ? ' DESC' : ''));
         this.condition = plan.where || '';
         this.partition = plan.partition;
     }

--- a/test/index-definition.spec.js
+++ b/test/index-definition.spec.js
@@ -1051,6 +1051,31 @@ describe('normalize', function() {
             .to.be.equalTo(['`key`']);
     });
 
+    it('handles descending keys', async function() {
+        let def = new IndexDefinition({
+            name: 'test',
+            index_key: 'key',
+            condition: 'type = \'beer\'',
+        });
+
+        let getQueryPlan = stub().returns(Promise.resolve({
+            keys: [
+                {expr: '`key`', desc: true},
+            ],
+            where: '`type` = "beer"',
+        }));
+
+        let manager = {
+            bucketName: 'test',
+            getQueryPlan: getQueryPlan,
+        };
+
+        await def.normalize(manager);
+
+        expect(def.index_key)
+            .to.be.equalTo(['`key` DESC']);
+    });
+
     it('replaces condition', async function() {
         let def = new IndexDefinition({
             name: 'test',


### PR DESCRIPTION
Motivation
----------
Couchbase Server 5.0 allows sorting any index_key in descending rather
than ascending order.

Modifications
-------------
When normalizing index_key use the `desc` boolean to correctly update
the statement.

Results
-------
For CB >= 5.0 any index_key may have DESC appended in the definition.

For CB < 5.0 an error will be thrown if DESC is encountered.