### PR TITLE
Issue #30: Include node list on create index plan output

### DIFF
--- a/app/create-index-mutation.js
+++ b/app/create-index-mutation.js
@@ -49,6 +49,11 @@ export class CreateIndexMutation extends IndexMutation {
                 chalk.greenBright(
                     `  Repl: ${this.definition.num_replica}`));
         }
+
+        if (this.withClause.nodes) {
+            logger.info(chalk.greenBright(
+                ` Nodes: ${this.withClause.nodes.join()}`));
+        }
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
Motivation
----------
Allow operator to review the assigned nodes from the plan prior to
executing the plan.

Modifications
-------------
Append the assigned nodes, if any, to the plan output for create index
mutations.

Results
-------
Operators can now see node assignments, when present.