### PR TITLE
Issue #27: Support for replicas on partitioned indexes

### DIFF
--- a/app/index-manager.js
+++ b/app/index-manager.js
@@ -137,9 +137,17 @@ export class IndexManager {
                 }
 
                 // add any hosts listed to index info
-                index.nodes.push(...status.hosts);
+                // but only for the first if partitioned (others will be dupes)
+                if (!index.partition || index.nodes.length === 0) {
+                    index.nodes.push(...status.hosts);
+                }
 
-                index.num_replica = index.nodes.length - 1;
+                // if this is the first found, set to 0, otherwise add 1
+                if (index.num_replica === undefined) {
+                    index.num_replica = 0;
+                } else {
+                    index.num_replica++;
+                }
             }
         });
 

--- a/example/beer-sample/default.yaml
+++ b/example/beer-sample/default.yaml
@@ -16,6 +16,9 @@ num_replica: 0
 name: DocsByType
 index_key:
 - type
+partition:
+  exprs:
+  - type
 ---
 name: BreweriesByAddress
 index_key:


### PR DESCRIPTION
Motivation
----------
Extend support for partitioned replicas on Couchbase Server 5.5 to
include replicas.

Modifications
-------------
Decouple num_replica and nodes list length for partitioned replicas.

Handle partitioned indexes differently when getting the list of nodes
for existing indexes, as each replica will have the same node list.

Prevent manual_replica from being used for partitioned indexes.
Couchbase internals for partioned indexes really need to use automatic
replicas so Couchbase can ensure partitions are kept on different nodes
for each replica.

Results
-------
Partitioned replicas are now supported with automatic replica
management.

There is a bug in Couchbase 5.5 Beta which will result in errors if you
specify both a list of nodes and a value for num_replica for a
partitioned index.  Until this bug is fixed, users should use only one
or the other, not both.  https://issues.couchbase.com/browse/MB-29321