### PR TITLE
Issue #32: Output replica count when plan is reducing to 0

### DIFF
--- a/app/update-index-mutation.js
+++ b/app/update-index-mutation.js
@@ -62,8 +62,9 @@ export class UpdateIndexMutation extends IndexMutation {
                     `     -> ${this.definition.condition || 'none'}`));
         }
 
-        if (!this.definition.manual_replica &&
-            this.definition.num_replica > 0) {
+        let hasReplica = Math.max(this.definition.num_replica,
+                                  this.existingIndex.num_replica) > 0;
+        if (!this.definition.manual_replica && hasReplica) {
             logger.info(
                 chalk.cyanBright(
                     `  Repl: ${this.definition.num_replica}`));

--- a/example/beer-sample/default.yaml
+++ b/example/beer-sample/default.yaml
@@ -16,9 +16,6 @@ num_replica: 0
 name: DocsByType
 index_key:
 - type
-partition:
-  exprs:
-  - type
 ---
 name: BreweriesByAddress
 index_key:


### PR DESCRIPTION
Motivation
----------
When reducing the number of replicas to zero, the Update statement in
the plan doesn't make clear what the change will be.

Modifications
-------------
Include the replica count in the Update statement of plans if either the
existing or new replica count is non-zero.

Results
-------
Operators can more readily see what changes their plan is making.