### PR TITLE
Reverse order of PARTITION and WHERE clauses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: node_js
 node_js:
-- node
+- "8"
 services:
 - docker
 before_script:

--- a/app/index-definition.js
+++ b/app/index-definition.js
@@ -461,15 +461,17 @@ export class IndexDefinition extends IndexDefinitionBase {
             statement = `CREATE INDEX ${indexName}`;
             statement += ` ON ${ensureEscaped(bucketName)}`;
             statement += ` (${this.index_key.join(', ')})`;
-
-            if (this.condition) {
-                statement += ` WHERE ${this.condition}`;
-            }
         }
 
         if (this.partition) {
             statement +=
                 ` PARTITION BY ${this.getPartitionString()}`;
+        }
+
+        if (!this.is_primary) {
+            if (this.condition) {
+                statement += ` WHERE ${this.condition}`;
+            }
         }
 
         withClause = _.extend({}, withClause, {


### PR DESCRIPTION
Motivation
-------------
WHERE clause was being added before the PARTITION clause in cases where both were used, causing invalid N1QL to be generated.

Modifications
------------------
Moved the addition of the WHERE clause to be after the PARTITION clause (if any) is added.