### PR TITLE
Separate definition loading from sync class

### DIFF
--- a/app/definition-loader.js
+++ b/app/definition-loader.js
@@ -1,0 +1,178 @@
+import chalk from 'chalk';
+import fs from 'fs';
+import {isObjectLike} from 'lodash';
+import path from 'path';
+import util from 'util';
+import yaml from 'js-yaml';
+import {IndexDefinition} from './index-definition';
+import {NodeMap} from './node-map';
+
+// Ensure that promisify is available on Node 6
+require('util.promisify').shim();
+
+const lstat = util.promisify(fs.lstat);
+const readdir = util.promisify(fs.readdir);
+const readFile = util.promisify(fs.readFile);
+
+const INDEX_EXTENSIONS = ['.json', '.yaml', '.yml'];
+
+/**
+ * Loads index definitions from disk or stdin
+ */
+export class DefinitionLoader {
+    /**
+     * @param {any} [logger]
+     */
+    constructor(logger) {
+        this.logger = logger || console;
+    }
+
+    /**
+     * Loads definitions from disk
+     *
+     * @param  {array.string} paths
+     * @return {{definitions: array.IndexDefinition, nodeMap: NodeMap}}
+     */
+    async loadDefinitions(paths) {
+        let definitions = [];
+        let nodeMap = new NodeMap();
+
+        let files = [];
+        for (let filePath of paths) {
+            if (filePath === '-') {
+                // read from stdin
+                await this.loadFromStdIn(
+                    (def) => this.processDefinition(definitions, nodeMap, def));
+
+                continue;
+            }
+
+            try {
+                if ((await lstat(filePath)).isDirectory()) {
+                    let filesInDir = await readdir(filePath);
+                    let joinedFilesInDir = filesInDir.map(
+                        (fileName) => path.join(filePath, fileName));
+
+                    files.push(...joinedFilesInDir);
+                } else {
+                    files.push(filePath);
+                }
+            } catch (e) {
+                throw new Error('Path not found');
+            }
+        }
+
+        // Only look at specific file types
+        files = files.filter((filename) =>
+            INDEX_EXTENSIONS.includes(path.extname(filename).toLowerCase()));
+
+        for (let i=0; i<files.length; i++) {
+            await this.loadDefinition(files[i],
+                (def) => this.processDefinition(definitions, nodeMap, def));
+        }
+
+        return {
+            definitions,
+            nodeMap,
+        };
+    }
+
+    /**
+     * @private
+     * Loads index definitions from a file
+     *
+     * @param {string} filename File to read
+     * @param {function(*)} handler Handler for loaded definitions
+     */
+    async loadDefinition(filename, handler) {
+        let ext = path.extname(filename).toLowerCase();
+        let contents = await readFile(filename, 'utf8');
+
+        if (ext === '.json') {
+            handler(JSON.parse(contents));
+        } else if (ext === '.yaml' || ext === '.yml') {
+            yaml.safeLoadAll(contents, handler);
+        }
+    }
+
+    /**
+     * @private
+     * Loads index definitions from stdin
+     *
+     * @param {function(IndexDefinition)} handler Handler for loaded definitions
+     * @return {Promise}
+     */
+    loadFromStdIn(handler) {
+        return new Promise((resolve, reject) => {
+            process.stdin.resume();
+            process.stdin.setEncoding('utf8');
+
+            let data = '';
+            process.stdin.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            process.stdin.on('end', () => {
+                try {
+                    if (data.match(/^\s*{/)) {
+                        // Appears to be JSON
+                        handler(JSON.parse(data));
+                    } else {
+                        // Assume it's YAML
+                        yaml.safeLoadAll(data, handler);
+                    }
+
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+        });
+    }
+
+    /**
+     * @private
+     * Processes a definition and adds to the current definitions or
+     *     applies overrides to the matching definition
+     *
+     * @param {array.IndexDefinition} definitions Current definitions
+     * @param {NodeMap} nodeMap Current node map
+     * @param {*} definition New definition to process
+     */
+    processDefinition(definitions, nodeMap, definition) {
+        let match = definitions.find((p) => p.name === definition.name);
+
+        if (definition.type === undefined) {
+            definition.type = 'index';
+        }
+
+        if (definition.type === 'nodeMap') {
+            if (definition.map && isObjectLike(definition.map)) {
+                nodeMap.merge(definition.map);
+            } else {
+                throw new Error('Invalid nodeMap');
+            }
+        } else if (definition.type === 'override') {
+            // Override definition
+            if (match) {
+                match.applyOverride(definition);
+            } else {
+                // Ignore overrides with no matching index
+                this.logger.warn(
+                    chalk.yellowBright(
+                        `No index definition found '${definition.name}'`));
+            }
+        } else if (definition.type === 'index') {
+            // Regular index definition
+
+            if (match) {
+                throw new Error(
+                    `Duplicate index definition '${definition.name}'`);
+            }
+
+            definitions.push(new IndexDefinition(definition));
+        } else {
+            throw new Error(`Unknown definition type '${definition.type}'`);
+        }
+    }
+}

--- a/app/sync.js
+++ b/app/sync.js
@@ -1,23 +1,9 @@
-import {compact, flatten, extend, isArrayLike, isObjectLike} from 'lodash';
-import fs from 'fs';
-import path from 'path';
-import util from 'util';
-import yaml from 'js-yaml';
+import {compact, flatten, extend, isArrayLike} from 'lodash';
 import chalk from 'chalk';
 import {prompt} from 'inquirer';
 import {Plan} from './plan';
-import {IndexDefinition} from './index-definition';
-import {NodeMap} from './node-map';
 import {FeatureVersions} from './feature-versions';
-
-// Ensure that promisify is available on Node 6
-require('util.promisify').shim();
-
-const lstat = util.promisify(fs.lstat);
-const readdir = util.promisify(fs.readdir);
-const readFile = util.promisify(fs.readFile);
-
-const INDEX_EXTENSIONS = ['.json', '.yaml', '.yml'];
+import {DefinitionLoader} from './definition-loader';
 
 /**
  * @typedef SyncOptions
@@ -43,7 +29,11 @@ export class Sync {
         this.manager = manager;
         this.paths = isArrayLike(path) ? Array.from(path) : [path];
         this.options = extend({logger: console}, options);
-        this.nodeMap = new NodeMap();
+
+        if (this.paths.find((p) => p === '-')) {
+            // Can't do interactive prompts if processing from stdin
+            this.options.interactive = false;
+        }
     }
 
     /**
@@ -76,7 +66,9 @@ export class Sync {
      * @return {Plan}
      */
     async createPlan() {
-        const definitions = await this.loadDefinitions();
+        const definitionLoader = new DefinitionLoader(this.options.logger);
+        const {definitions, nodeMap} =
+            await definitionLoader.loadDefinitions(this.paths);
 
         if (definitions.length === 0) {
             this.options.logger.warn(
@@ -88,7 +80,7 @@ export class Sync {
         }
 
         // Apply the node map
-        this.nodeMap.apply(definitions);
+        nodeMap.apply(definitions);
 
         const mutationContext = {
             currentIndexes: await this.manager.getIndexes(),
@@ -142,150 +134,5 @@ export class Sync {
         });
 
         return answers.confirm;
-    }
-
-    /**
-     * @private
-     * Loads definitions from disk
-     *
-     * @return {array.IndexDefinition}
-     */
-    async loadDefinitions() {
-        let definitions = [];
-
-        let files = [];
-        for (let filePath of this.paths) {
-            if (filePath === '-') {
-                // read from stdin
-
-                await this.loadFromStdIn(
-                    (def) => this.processDefinition(definitions, def));
-
-                // Can't do interactive prompts if processing from stdin
-                this.options.interactive = false;
-
-                continue;
-            }
-
-            try {
-                if ((await lstat(filePath)).isDirectory()) {
-                    let filesInDir = await readdir(filePath);
-                    let joinedFilesInDir = filesInDir.map(
-                        (fileName) => path.join(filePath, fileName));
-
-                    files.push(...joinedFilesInDir);
-                } else {
-                    files.push(filePath);
-                }
-            } catch (e) {
-                throw new Error('Path not found');
-            }
-        }
-
-        // Only look at specific file types
-        files = files.filter((filename) =>
-            INDEX_EXTENSIONS.includes(path.extname(filename).toLowerCase()));
-
-        for (let i=0; i<files.length; i++) {
-            await this.loadDefinition(files[i],
-                (def) => this.processDefinition(definitions, def));
-        }
-
-        return definitions;
-    }
-
-    /**
-     * @private
-     * Loads index definitions from a file
-     *
-     * @param {string} filename File to read
-     * @param {function(*)} handler Handler for loaded definitions
-     */
-    async loadDefinition(filename, handler) {
-        let ext = path.extname(filename).toLowerCase();
-        let contents = await readFile(filename, 'utf8');
-
-        if (ext === '.json') {
-            handler(JSON.parse(contents));
-        } else if (ext === '.yaml' || ext === '.yml') {
-            yaml.safeLoadAll(contents, handler);
-        }
-    }
-
-    /**
-     * @private
-     * Loads index definitions from stdin
-     *
-     * @param {function(IndexDefinition)} handler Handler for loaded definitions
-     * @return {Promise}
-     */
-    loadFromStdIn(handler) {
-        return new Promise((resolve, reject) => {
-            process.stdin.resume();
-            process.stdin.setEncoding('utf8');
-
-            let data = '';
-            process.stdin.on('data', (chunk) => {
-                data += chunk;
-            });
-
-            process.stdin.on('end', () => {
-                try {
-                    if (data.match(/^\s*{/)) {
-                        // Appears to be JSON
-                        handler(JSON.parse(data));
-                    } else {
-                        // Assume it's YAML
-                        yaml.safeLoadAll(data, handler);
-                    }
-
-                    resolve();
-                } catch (e) {
-                    reject(e);
-                }
-            });
-        });
-    }
-
-    /**
-     * @private
-     * Processes a definition and adds to the current definitions or
-     *     applies overrides to the matching definition
-     *
-     * @param {array.IndexDefinition} definitions Current definitions
-     * @param {*} definition New definition to process
-     */
-    processDefinition(definitions, definition) {
-        let match = definitions.find((p) => p.name === definition.name);
-
-        if (definition.type === 'nodeMap') {
-            if (definition.map && isObjectLike(definition.map)) {
-                this.nodeMap.merge(definition.map);
-            } else {
-                throw new Error('Invalid nodeMap');
-            }
-        } else if (definition.type === 'override') {
-            // Override definition
-            if (match) {
-                match.applyOverride(definition);
-            } else {
-                // Ignore overrides with no matching index
-                this.options.logger.warn(
-                    chalk.yellowBright(
-                        `No index definition found '${definition.name}'`));
-            }
-        } else if (definition.type === undefined
-            || definition.type === 'index') {
-            // Regular index definition
-
-            if (match) {
-                throw new Error(
-                    `Duplicate index definition '${definition.name}'`);
-            }
-
-            definitions.push(new IndexDefinition(definition));
-        } else {
-            throw new Error(`Unknown definition type '${definition.type}'`);
-        }
     }
 }


### PR DESCRIPTION
Motivation
----------
Allow definition loading to be used by other processes in future work,
such as definition validation.

Modifications
-------------
Moved definition loading logic from sync.js to definition-loader.js.