### PR TITLE
Validate index definitions as they are loaded

### DIFF
--- a/app/index-definition.js
+++ b/app/index-definition.js
@@ -87,6 +87,109 @@ function ensurePort(server) {
 }
 
 /**
+ * Validators for the incoming index properties.
+ */
+export const IndexValidators = {
+    is_primary: function(val) {
+        if (val !== undefined && !_.isBoolean(val)) {
+            throw new Error('is_primary must be a boolean');
+        }
+    },
+    index_key: function(val) {
+        if (val === undefined) {
+            return;
+        }
+
+        if (!_.isArrayLike(val)) {
+            val = [val];
+        }
+
+        for (let v of val) {
+            if (!_.isString(v)) {
+                throw new Error(
+                    'index_key must be a string or array of strings');
+            }
+        }
+    },
+    condition: function(val) {
+        if (val !== undefined && !_.isString(val)) {
+            throw new Error('condition must be a string');
+        }
+    },
+    partition: function(val) {
+        if (val === undefined) {
+            return;
+        }
+
+        if (!_.isObjectLike(val)) {
+            throw new Error('Invalid partition');
+        }
+
+        _.forOwn(val, (v) => {
+            if (!_.isString(v)) {
+                throw new Error('Invalid partition');
+            }
+        });
+    },
+    nodes: function(val) {
+        if (val !== undefined) {
+            if (!_.isArrayLike(val)) {
+                throw new Error('nodes must be an array of strings');
+            }
+
+            val.forEach((v) => {
+                if (!_.isString(v)) {
+                    throw new Error(
+                        'nodes must be an array of strings');
+                }
+            });
+        }
+    },
+    manual_replica: function(val) {
+        if (val !== undefined && !_.isBoolean(val)) {
+            throw new Error('manual_replica must be a boolean');
+        }
+    },
+    num_replica: function(val) {
+        if (val !== undefined && !_.isNumber(val)) {
+            throw new Error('num_replica must be a number');
+        }
+    },
+    lifecycle: function(val) {
+        if (val !== undefined && !_.isObjectLike(val)) {
+            throw new Error('lifecycle is invalid');
+        }
+    },
+    post_validate: function() {
+        if (!this.is_primary) {
+            if (!this.index_key || this.index_key.length === 0) {
+                throw new Error('index_key must include at least one key');
+            }
+        } else {
+            if (this.index_key && this.index_key.length > 0) {
+                throw new Error('index_key is not allowed for a primary index');
+            }
+
+            if (this.condition) {
+                throw new Error('condition is not allowed for a primary index');
+            }
+        }
+
+        if (this.partition && this.manual_replica) {
+            throw new Error(
+                'manual_replica is not supported on partioned indexes');
+        }
+
+        if (!this.partition && this.nodes) {
+            // Validate nodes and num_replica values
+            if (this.nodes.length !== this.num_replica + 1) {
+                throw new Error('mismatch between num_replica and nodes');
+            }
+        }
+    },
+};
+
+/**
  * @type Object<string, function(*)>
  *
  * Map of processing functions to handle hash keys.
@@ -217,31 +320,7 @@ export class IndexDefinition extends IndexDefinitionBase {
         });
 
         // Validate the resulting defintion
-        if (!this.is_primary) {
-            if (this.index_key.length === 0) {
-                throw new Error('index_key must include at least one key');
-            }
-        } else {
-            if (this.index_key.length > 0) {
-                throw new Error('index_key is not allowed for a primary index');
-            }
-
-            if (this.condition) {
-                throw new Error('condition is not allowed for a primary index');
-            }
-        }
-
-        if (this.partition && this.manual_replica) {
-            throw new Error(
-                'manual_replica is not supported on partioned indexes');
-        }
-
-        if (!this.partition && this.nodes) {
-            // Validate nodes and num_replica values
-            if (this.nodes.length !== this.num_replica + 1) {
-                throw new Error('mismatch between num_replica and nodes');
-            }
-        }
+        IndexValidators.post_validate.call(this);
     }
 
     /**

--- a/app/node-map.js
+++ b/app/node-map.js
@@ -1,4 +1,21 @@
-import {extend} from 'lodash';
+import {extend, forOwn, isObjectLike, isString} from 'lodash';
+
+/**
+ * Validators for the incoming node map properties.
+ */
+export const NodeMapValidators = {
+    map: function(map) {
+        if (!isObjectLike(map)) {
+            throw new Error('Invalid node map');
+        }
+
+        forOwn(map, (v) => {
+            if (!isString(v)) {
+                throw new Error('Invalid node map');
+            }
+        });
+    },
+};
 
 /**
  * Stores a map of node aliases to their fully qualified name


### PR DESCRIPTION
Motivation
----------
Help support a future "validate" command to allow CI tools to validate
index definitions as they are committed to source control.

Modifications
-------------
Add index definition property validates to index-definition.js and
node-map.js.  Use these validators during the load process in
definition-loader.js.