### PR TITLE
Add validate command line syntax

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,25 @@
                 "${workspaceRoot}/node_modules/**/*.js",
                 "<node_internals>/**/*.js"
             ]
-        }
+        },
+        {
+          "type": "node",
+          "request": "launch",
+          "name": "Validate",
+          "program": "${workspaceFolder}/bin/couchbase-index-manager",
+          "runtimeArgs": ["--nolazy"],
+          "args": [
+              "validate",
+              "./example/beer-sample"
+          ],
+          "console": "integratedTerminal",
+          "sourceMaps": true,
+          "smartStep": true,
+          "outFiles": ["${workspaceRoot}/dist/**/*.js"],
+          "skipFiles": [
+              "${workspaceRoot}/node_modules/**/*.js",
+              "<node_internals>/**/*.js"
+          ]
+      }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -45,12 +45,31 @@ cat definitions.yaml | couchbase-index-manager -c couchbase://node -u Administra
 - *-t 30* - Seconds to wait for index build to complete, 0 for infinite (default 5m)
 - *--bucket-password password* - For 4.x clusters, provides the bucket password for secure buckets
 
-### Examples
+### Sync Examples
 
 ```sh
 couchbase-index-manager -c couchbase://localhost -u Administrator -p password sync beer-sample ./directory/
 couchbase-index-manager -c couchbase://localhost -u Administrator -p password sync beer-sample ./directory/file.yaml
 couchbase-index-manager -c couchbase://localhost -u Administrator -p password sync beer-sample ./directory/file.json
+```
+
+## Validate Command
+
+```sh
+couchbase-index-manager [common-options] validate [validate-options] <path...>
+```
+
+The validate command loads definition files and confirms they are valid. This is typically used as part of a continuous integration process for repositories containing definition files.
+
+Optionally, the validate command can connect to a Couchbase cluster and use EXPLAIN on CREATE INDEX commands to further validate the syntax of the definitions.  When using `--validate-syntax`, a bucket name must be provided.
+
+### Validate Examples
+
+```sh
+couchbase-index-manager validate ./directory/
+couchbase-index-manager validate ./directory/file.yaml
+couchbase-index-manager validate ./directory/file.json
+couchbase-index-manager -c couchbase://localhost -u Administrator -p password validate --validate-syntax beer-sample ./directory/
 ```
 
 ## Definition Files

--- a/app/cli.js
+++ b/app/cli.js
@@ -4,6 +4,7 @@ import pkg from './../package.json';
 import chalk from 'chalk';
 import {ConnectionManager} from './connection-manager';
 import {Sync} from './sync';
+import {Validator} from './validator';
 
 /**
  * Parses options from the parent command, such as cluster, username,
@@ -62,6 +63,31 @@ export function run() {
         .option(
             '--no-color',
             'Supress color in output'); // Applied automatically by chalk
+
+    program
+        .command('validate <path...>')
+        .description('Validates index definition files')
+        .option(
+            '--validate-syntax <bucket-name>',
+            'Connect to Couchbase and fully validate syntax')
+        .action((path, cmd) => {
+            let validator = new Validator(path);
+
+            if (cmd.validateSyntax) {
+                let connectionInfo = extend(
+                    parseBaseOptions(cmd),
+                    {
+                        bucketName: cmd.validateSyntax,
+                    });
+
+                let connectionManager = new ConnectionManager(connectionInfo);
+                handleAsync(connectionManager.execute((manager) => {
+                    return validator.execute(manager);
+                }));
+            } else {
+                handleAsync(validator.execute());
+            }
+        });
 
     program
         .command('sync <bucket> <path...>')

--- a/app/validator.js
+++ b/app/validator.js
@@ -1,0 +1,79 @@
+import {extend, isArrayLike} from 'lodash';
+import chalk from 'chalk';
+import {FeatureVersions} from './feature-versions';
+import {DefinitionLoader} from './definition-loader';
+
+/**
+ * @typedef ValidateOptions
+ * @property {?object} logger Logger for printing information
+ */
+
+/**
+ * Executes a synchronization, loading definitions from disk
+ */
+export class Validator {
+    /**
+     * @param {string | array.string} path
+     *     Path or array of paths to files or directories with index definitions
+     * @param {ValidateOptions} [options]
+     */
+    constructor(path, options) {
+        this.paths = isArrayLike(path) ? Array.from(path) : [path];
+        this.options = extend({logger: console}, options);
+    }
+
+    /**
+     * Executes the synchronization
+     *
+     * @param  {IndexManager} [manager]
+     */
+    async execute(manager) {
+        const definitionLoader = new DefinitionLoader(this.options.logger);
+        const {definitions, nodeMap} =
+            await definitionLoader.loadDefinitions(this.paths);
+
+        if (manager) {
+            await this.validateSyntax(manager, definitions, nodeMap);
+        }
+
+        this.options.logger.log(
+            chalk.greenBright('Definitions validated, no errors found.'));
+    }
+
+    /**
+     * @private
+     * Uses EXPLAIN to validate syntax of the CREATE INDEX statement.
+     *
+     * @param {IndexManager} manager
+     * @param {array.IndexDefinition} definitions
+     * @param {NodeMap} nodeMap
+     */
+    async validateSyntax(manager, definitions, nodeMap) {
+        const clusterVersion = await manager.getClusterVersion();
+
+        if (!FeatureVersions.autoReplicas(clusterVersion)) {
+            // Force all definitions to use manual replica management
+            definitions.forEach((def) => {
+                def.manual_replica = true;
+            });
+        }
+
+        nodeMap.apply(definitions);
+
+        for (let definition of definitions) {
+            let statement = definition.getCreateStatement(
+                manager.bucketName, '__cbim_validate');
+
+            try {
+                // Use an EXPLAIN CREATE INDEX statement to validate the syntax.
+                // So long as there is no real index named __cbim_validate, this
+                // will ensure the condition syntax, etc, is correct.
+
+                await manager.getQueryPlan(statement);
+            } catch (e) {
+                throw new Error(
+                    `Invalid index definition for ${this.name}: ${e.message}`);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
Allow CI tooling to validate index definition syntax.

Modifications
-------------
Added validate command to cli.js, and validator.js to perform the
validation process.

Results
-------
Index definitions can be validated.  For more complete validation,
--validate-syntax argument will validate the generated N1QL statements
against a Couchbase cluster.