### PR TITLE
Add support for retain_deleted_xattr

### DIFF
--- a/app/create-index-mutation.js
+++ b/app/create-index-mutation.js
@@ -54,6 +54,11 @@ export class CreateIndexMutation extends IndexMutation {
             logger.info(chalk.greenBright(
                 ` Nodes: ${this.withClause.nodes.join()}`));
         }
+
+        if (this.withClause.retain_deleted_xattr) {
+            logger.info(chalk.greenBright(
+                ' XATTR: true'));
+        }
     }
 
     /** @inheritDoc */

--- a/app/index-manager.js
+++ b/app/index-manager.js
@@ -116,6 +116,9 @@ export class IndexManager {
                 } else {
                     index.num_replica++;
                 }
+
+                index.retain_deleted_xattr =
+                    /"retain_deleted_xattr"\s*:\s*true/.test(status.definition);
             }
         });
 

--- a/app/update-index-mutation.js
+++ b/app/update-index-mutation.js
@@ -77,6 +77,14 @@ export class UpdateIndexMutation extends IndexMutation {
             logger.info(chalk.cyanBright(
                 `    ->: ${this.withClause.nodes.join()}`));
         }
+
+        if (!isEqual(!!this.withClause.retain_deleted_xattr,
+            this.existingIndex.retain_deleted_xattr)) {
+            logger.info(chalk.cyanBright(
+                ` XATTR: ${this.existingIndex.retain_deleted_xattr}`));
+            logger.info(chalk.cyanBright(
+                `    ->: ${!!this.withClause.retain_deleted_xattr}`));
+        }
     }
 
     /** @inheritDoc */

--- a/example/beer-sample/default.yaml
+++ b/example/beer-sample/default.yaml
@@ -36,3 +36,8 @@ map:
   node1: node1.cbindexmgr
   node2: node2.cbindexmgr
   node3: node3.cbindexmgr
+---
+name: sg_roleAccess_x1
+index_key:
+- (all (array (`op`.`name`) for `op` in object_pairs((((meta().`xattrs`).`_sync`).`role_access`)) end))
+retain_deleted_xattr: false

--- a/test/index-definition.spec.js
+++ b/test/index-definition.spec.js
@@ -187,6 +187,27 @@ describe('ctor', function() {
         expect(def.partition)
             .to.be.undefined;
     });
+
+    it('no retain_deleted_xattr is false', function() {
+        let def = new IndexDefinition({
+            name: 'test',
+            index_key: 'key',
+        });
+
+        expect(def.retain_deleted_xattr)
+            .to.equal(false);
+    });
+
+    it('retain_deleted_xattr sets value', function() {
+        let def = new IndexDefinition({
+            name: 'test',
+            index_key: 'key',
+            retain_deleted_xattr: true,
+        });
+
+        expect(def.retain_deleted_xattr)
+            .to.equal(true);
+    });
 });
 
 describe('applyOverride', function() {


### PR DESCRIPTION
Motivation
----------
Including retain_deleted_xattr in the WITH clause is desirable for
Sync Gateway support.

Modifications
-------------
Include retain_deleted_xattr in the index definition, and apply it to
the with clause when true. Also include it in the index change logic to
drop/recreate the index.

Closes #53