### PR TITLE
Add support for num_partition

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,3 +14,4 @@ rules:
   no-console: "off"
   indent: "off"
   prefer-const: "off"
+  max-len: [2, 120]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ lifecycle:
 | partition          | N | For CB 5.5, object to specify index partitioning |
 | partition.exprs    | Y | Required if `partition` is present, array of strings for attributes used to create partition |
 | partition.stragegy | N | Partition strategy to use, defaults to `hash` |
+| partition.num_partition | N | Number of partitions, defaults to 8 |
 | manual_replica     | N | Force manual replica management, rather than using Couchbase 5.X automatic replicas. Automatically set to true for Couchbase 4.X. |
 | num_replica        | N | Defaults to 0, number of index replicas to create. |
 | nodes              | N | List of nodes for index placement.  Automatic placement is used if not present. |
@@ -138,6 +139,7 @@ Overrides are processed in the order they are found, and can only override index
 | partition          | N | For CB 5.5, object to specify index partitioning.  Use `null` to remove partition during override. |
 | partition.exprs    | N | Array of strings for attributes used to create partition, replaces the existing array. |
 | partition.stragegy | N | Partition strategy to use |
+| partition.num_partition | N | Number of partitions, defaults to 8 |
 | manual_replica     | N | Force manual replica management, rather than using Couchbase 5.X automatic replicas. Automatically set to true for Couchbase 4.X. |
 | num_replica        | N | Number of index replicas to create. |
 | nodes              | N | List of nodes for index placement. |

--- a/app/cli.js
+++ b/app/cli.js
@@ -146,8 +146,11 @@ export function run() {
             console.log();
             console.log('  Examples:');
             console.log();
+            // eslint-disable-next-line max-len
             console.log('    $ couchbase-index-manager -c couchbase://localhost -u Administrator -p password sync beer-sample ./directory/');
+            // eslint-disable-next-line max-len
             console.log('    $ couchbase-index-manager -c couchbase://localhost -u Administrator -p password sync beer-sample ./directory/file.yaml');
+            // eslint-disable-next-line max-len
             console.log('    $ couchbase-index-manager -c couchbase://localhost -u Administrator -p password sync beer-sample ./directory/file.json');
         });
 

--- a/app/create-index-mutation.js
+++ b/app/create-index-mutation.js
@@ -41,6 +41,12 @@ export class CreateIndexMutation extends IndexMutation {
             logger.info(
                 chalk.greenBright(
                     `  Part: ${this.definition.getPartitionString()}`));
+
+            if (this.definition.partition.num_partition) {
+                logger.info(
+                    chalk.greenBright(
+                        `# Part: ${this.definition.partition.num_partition}`));
+            }
         }
 
         if (this.definition.num_replica > 0 &&

--- a/app/update-index-mutation.js
+++ b/app/update-index-mutation.js
@@ -44,12 +44,24 @@ export class UpdateIndexMutation extends IndexMutation {
                     `     -> ${this.formatKeys(this.definition)}`));
         }
 
-        if (!isEqual(this.existingIndex.partition || '',
-            this.definition.getPartitionString())) {
-            logger.info(chalk.cyanBright(
-                `  Part: ${this.existingIndex.partition || 'none'}`));
-            logger.info(chalk.cyanBright(
-                `     -> ${this.definition.getPartitionString() || 'none'}`));
+        if (this.definition.partition || this.existingIndex.partition) {
+            if (!isEqual(this.existingIndex.partition || '',
+                this.definition.getPartitionString())) {
+                logger.info(chalk.cyanBright(
+                    `  Part: ${this.existingIndex.partition || 'none'}`));
+                logger.info(chalk.cyanBright(
+                    `     -> ${this.definition.getPartitionString() || 'none'}`));
+            }
+
+            if (this.definition.partition &&
+                this.definition.partition.num_partition &&
+                this.existingIndex.num_partition !==
+                    this.definition.partition.num_partition) {
+                logger.info(chalk.cyanBright(
+                    `# Part: ${this.existingIndex.num_partition}`));
+                logger.info(chalk.cyanBright(
+                    `     -> ${this.definition.partition.num_partition}`));
+            }
         }
 
         if (!isEqual(this.existingIndex.condition || '',

--- a/test/index-definition.spec.js
+++ b/test/index-definition.spec.js
@@ -548,6 +548,57 @@ describe('getMutation partition change', function() {
             .to.have.length(0);
     });
 
+    it('ignores matching num_partition', function() {
+        let def = new IndexDefinition({
+            name: 'test',
+            index_key: '`key`',
+            partition: {
+                exprs: ['`test`'],
+                num_partition: 3,
+            },
+        });
+
+        let mutations = [...def.getMutations({
+            currentIndexes: [
+                {
+                    name: 'test',
+                    index_key: ['`key`'],
+                    partition: 'HASH(`test`)',
+                    num_partition: 3,
+                    nodes: ['a:8091'],
+                },
+            ],
+        })];
+
+        expect(mutations)
+            .to.have.length(0);
+    });
+
+    it('ignores missing num_partition', function() {
+        let def = new IndexDefinition({
+            name: 'test',
+            index_key: '`key`',
+            partition: {
+                exprs: ['`test`'],
+            },
+        });
+
+        let mutations = [...def.getMutations({
+            currentIndexes: [
+                {
+                    name: 'test',
+                    index_key: ['`key`'],
+                    partition: 'HASH(`test`)',
+                    num_partition: 8,
+                    nodes: ['a:8091'],
+                },
+            ],
+        })];
+
+        expect(mutations)
+            .to.have.length(0);
+    });
+
     it('updates if partition does not match', function() {
         let def = new IndexDefinition({
             name: 'test',
@@ -563,6 +614,34 @@ describe('getMutation partition change', function() {
                     name: 'test',
                     index_key: ['`key`'],
                     partition: 'HASH(`test2`)',
+                    nodes: ['a:8091'],
+                },
+            ],
+        })];
+
+        expect(mutations)
+            .to.have.length(1);
+        expect(mutations[0])
+            .to.be.instanceof(UpdateIndexMutation);
+    });
+
+    it('updates if num_partition does not match', function() {
+        let def = new IndexDefinition({
+            name: 'test',
+            index_key: '`key`',
+            partition: {
+                exprs: ['`test`'],
+                num_partition: 3,
+            },
+        });
+
+        let mutations = [...def.getMutations({
+            currentIndexes: [
+                {
+                    name: 'test',
+                    index_key: ['`key`'],
+                    partition: 'HASH(`test2`)',
+                    num_partition: 8,
                     nodes: ['a:8091'],
                 },
             ],


### PR DESCRIPTION
Motivation
----------
Allow the number of partitions in a partitioned index to be manually
controlled.

Modifications
-------------
Added an option to the partition definition to control the number of
partitions. If missing, the number is ignored. If present, the index
is synchronized to have that number of partitions.

Fixed a bug in SDK 3.x upgrade that prevented partitioned indexes from
working as expected.

Closes #52