### PR TITLE
Add support for ALTER INDEX replica_count

### DIFF
--- a/app/feature-versions.js
+++ b/app/feature-versions.js
@@ -22,6 +22,18 @@ export class FeatureVersions {
     }
 
     /**
+     * Tests for ALTER INDEX replica_count compatibility
+     *
+     * @param  {Version} version
+     * @return {boolean}
+     */
+    static alterIndexReplicaCount(version) {
+        return version &&
+            (version.major > 6 ||
+            (version.major == 6 && version.minor >= 5));
+    }
+
+    /**
      * Tests for PARTITION BY compatibility
      *
      * @param  {Version} version

--- a/app/index-definition.js
+++ b/app/index-definition.js
@@ -4,6 +4,7 @@ import {CreateIndexMutation} from './create-index-mutation';
 import {UpdateIndexMutation} from './update-index-mutation';
 import {DropIndexMutation} from './drop-index-mutation';
 import {MoveIndexMutation} from './move-index-mutation';
+import {ResizeIndexMutation} from './resize-index-mutation';
 import {FeatureVersions} from './feature-versions';
 
 /**
@@ -401,9 +402,13 @@ export class IndexDefinition extends IndexDefinitionBase {
             // Number of replicas changed for an auto replica index
             // We must drop and recreate.
 
-            yield new UpdateIndexMutation(this, this.name + suffix,
-                this.getWithClause(replicaNum),
-                currentIndex);
+            if (FeatureVersions.alterIndexReplicaCount(context.clusterVersion)) {
+                yield new ResizeIndexMutation(this, this.name + suffix);
+            } else {
+                yield new UpdateIndexMutation(this, this.name + suffix,
+                    this.getWithClause(replicaNum),
+                    currentIndex);
+            }
         } else if (this.nodes && currentIndex.nodes) {
             // Check for required node changes
             currentIndex.nodes.sort();

--- a/app/index-manager.js
+++ b/app/index-manager.js
@@ -168,6 +168,32 @@ export class IndexManager {
     }
 
     /**
+     * Moves index replicas been nodes
+     * @param {string} indexName
+     * @param {number} numReplica
+     * @param {?array.string} nodes
+     * @return {Promise}
+     */
+    resizeIndex(indexName, numReplica, nodes) {
+        let statement = 'ALTER INDEX ' +
+            `\`${this.bucketName}\`.\`${indexName}\`` +
+            ' WITH ';
+
+        let withClause = {
+            action: 'replica_count',
+            num_replica: numReplica,
+        };
+
+        if (nodes) {
+            withClause.nodes = nodes;
+        }
+
+        statement += JSON.stringify(withClause);
+
+        return this.cluster.query(statement);
+    }
+
+    /**
      * Builds any outstanding deferred indexes on the bucket
      * @return {Promise} Promise triggered once build is started (not completed)
      */

--- a/app/resize-index-mutation.js
+++ b/app/resize-index-mutation.js
@@ -1,0 +1,52 @@
+import {IndexMutation} from './index-mutation';
+import chalk from 'chalk';
+
+/**
+ * @typedef CouchbaseIndex
+ * @property {string} name
+ * @property {array.string} index_key
+ * @property {?string} condition
+ */
+
+ /**
+ * Represents an index mutation which resizes an existing index to a different number of replicas
+ */
+export class ResizeIndexMutation extends IndexMutation {
+    /**
+     * @param {IndexDefinition} definition Index definition
+     * @param {string} name Name of the index to mutate
+     * @param {boolean} unsupported
+     *     If true, don't actually perform this mutation
+     */
+    constructor(definition, name) {
+        super(definition, name);
+    }
+
+    /** @inheritDoc */
+    print(logger) {
+        const color = this.unsupported ?
+            chalk.yellowBright :
+            chalk.cyanBright;
+
+        logger.info(color(
+            `Resize: ${this.name}`));
+
+        logger.info(color(
+            `  Repl: ${this.definition.num_replica}`));
+
+        if (this.definition.nodes) {
+            logger.info(color(
+                ` Nodes: ${this.definition.nodes.join()}`));
+        }
+    }
+
+    /** @inheritDoc */
+    async execute(manager, logger) {
+        await manager.resizeIndex(this.name, this.definition.num_replica, this.definition.nodes);
+    }
+
+    /** @inheritDoc */
+    isSafe() {
+        return true;
+    }
+}


### PR DESCRIPTION
Motivation
----------
Allow the number of replicas for an existing index to be changed without
downtime using the ALTER INDEX statement on Couchbase Server 6.5.

Modifications
-------------
Add ResizeIndexMutation and wire it up to be used whenever the Couchbase
server is on at least version 6.5.

Results
-------
Safe changes with no index downtime are performed if the number of
replicas is changed and the server is on 6.5 of later. No changes to
behavior for older Couchbase Server versions.

Close #56