### PR TITLE
Avoid name conflicts with scope/collections

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -116,9 +116,14 @@ services:
             -u Administrator -p password && break
         done;
         while true; do
-          sleep 3;
           ./cbdocloader -n node1.cbindexmgr -u Administrator -p password \
-            -b beer-sample -s 100 -d /opt/couchbase/samples/beer-sample.zip && break
+            -b beer-sample -s 100 -d /opt/couchbase/samples/beer-sample.zip && break;
+          sleep 3;
+        done;
+        while true; do
+          ./cbdocloader -n node1.cbindexmgr -u Administrator -p password \
+            -b travel-sample -s 100 -d /opt/couchbase/samples/travel-sample.zip && break;
+          sleep 3;
         done;
         echo "Initialized" > /initialized;
       fi

--- a/app/definition/index-definition.ts
+++ b/app/definition/index-definition.ts
@@ -7,7 +7,7 @@ import { MoveIndexMutation } from '../plan/move-index-mutation';
 import { ResizeIndexMutation } from '../plan/resize-index-mutation';
 import { FeatureVersions, Version } from '../feature-versions';
 import { IndexValidators } from '../configuration/index-validation';
-import { CouchbaseIndex, IndexManager, WithClause } from '../index-manager';
+import { CouchbaseIndex, DEFAULT_COLLECTION, DEFAULT_SCOPE, IndexManager, WithClause } from '../index-manager';
 import { IndexConfiguration, IndexConfigurationBase, Lifecycle, Partition, PartitionStrategy, PostProcessHandler } from '../configuration';
 import { IndexMutation } from '../plan/index-mutation';
 
@@ -331,13 +331,18 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
      * Tests to see if a Couchbase index matches this definition
      */
     private isMatch(index: CouchbaseIndex, suffix?: string): boolean {
+        // First validate we're in the correct collection
+        // TODO: Allow definition to specify a scope/collection
+        if (index.scope !== DEFAULT_SCOPE || index.collection !== DEFAULT_COLLECTION) {
+            return false;
+        }
+
+        // Then validate the name
         if (this.is_primary) {
             // Consider any primary index a match, regardless of name
             return index.is_primary;
         } else {
-            return (
-                ensureEscaped(this.name + (suffix || '')) ===
-                ensureEscaped(index.name));
+            return ensureEscaped(this.name + (suffix || '')) === ensureEscaped(index.name);
         }
     }
 

--- a/app/plan/plan.ts
+++ b/app/plan/plan.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { padStart, flatten } from 'lodash';
-import { IndexManager } from '../index-manager';
+import { IndexManager, WaitForIndexBuildOptions } from '../index-manager';
 import { IndexMutation } from './index-mutation';
 import { Logger } from '../options';
 
@@ -137,8 +137,11 @@ export class Plan {
             }
             await this.manager.buildDeferredIndexes();
 
-            if (!await this.manager.waitForIndexBuild(
-                this.options.buildTimeout, this.indexBuildTickHandler, this)) {
+            const waitOptions: WaitForIndexBuildOptions = {
+                timeoutMs: this.options.buildTimeout
+            }
+
+            if (!await this.manager.waitForIndexBuild(waitOptions, this.indexBuildTickHandler, this)) {
                 this.options.logger.warn(
                     chalk.yellowBright('Some indexes are not online'));
             }

--- a/example/travel-sample/default.yaml
+++ b/example/travel-sample/default.yaml
@@ -1,0 +1,11 @@
+name: def_primary
+is_primary: true
+---
+name: def_airportname 
+index_key:
+- airportname
+---
+name: def_name_type
+index_key:
+- name
+condition: _type = 'User'


### PR DESCRIPTION
Motivation
------------
Scopes and collections allow indexes with the same name across different
collections.

Modifications
---------------
Normalize the API responses for scope/collection information, and when
matching an index ensure we account for the scope/collection.

When building indices or waiting for the build to complete, target a specific
scope/collection (or default).

Add travel-sample to the dev environment since it has scopes/collections.

Results
--------
couchbase-index-manager is now compatible with scopes/collections in Couchbase
Server 7.0. The presense of indices within a collectdion will no longer confuse it.

However, it isn't yet capable of managing indices in a collection.