### PR TITLE
Add collection support to plans

### DIFF
--- a/app/plan/create-index-mutation.ts
+++ b/app/plan/create-index-mutation.ts
@@ -17,7 +17,7 @@ export class CreateIndexMutation extends IndexMutation {
     }
 
     print(logger: Logger): void {
-        logger.info(chalk.greenBright(`Create: ${this.name}`));
+        logger.info(chalk.greenBright(`Create: ${this.displayName}`));
 
         if (this.definition.is_primary) {
             logger.info(
@@ -66,7 +66,7 @@ export class CreateIndexMutation extends IndexMutation {
     }
 
     async execute(indexManager: IndexManager, logger: Logger): Promise<void> {
-        logger.info(chalk.greenBright(`Creating ${this.name}...`));
+        logger.info(chalk.greenBright(`Creating ${this.displayName}...`));
 
         const statement = this.definition.getCreateStatement(
             indexManager.bucketName, this.name, this.withClause

--- a/app/plan/drop-index-mutation.ts
+++ b/app/plan/drop-index-mutation.ts
@@ -8,13 +8,13 @@ import { Logger } from '../options';
  */
 export class DropIndexMutation extends IndexMutation {
     print(logger: Logger): void {
-        logger.info(chalk.redBright(`Delete: ${this.name}`));
+        logger.info(chalk.redBright(`Delete: ${this.displayName}`));
     }
 
     async execute(indexManager: IndexManager, logger: Logger): Promise<void> {
-        logger.info(chalk.redBright(`Deleting ${this.name}...`));
+        logger.info(chalk.redBright(`Deleting ${this.displayName}...`));
 
-        await indexManager.dropIndex(this.name);
+        await indexManager.dropIndex(this.name, this.scope, this.collection);
     }
 
     isSafe(): boolean {

--- a/app/plan/index-mutation.ts
+++ b/app/plan/index-mutation.ts
@@ -1,18 +1,34 @@
 import { IndexDefinition } from "../definition";
-import { IndexManager } from "../index-manager";
+import { DEFAULT_COLLECTION, DEFAULT_SCOPE, IndexManager } from "../index-manager";
 import { Logger } from "../options";
 
 /**
  * Abstract base class for index mutations
  */
 export abstract class IndexMutation {
-    name: string;
+    readonly name: string;
+    readonly scope: string;
+    readonly collection: string;
     phase: number;
+
+    /**
+     * A display name for the index which includes the scope and collection if non-default.
+     */
+    get displayName(): string {
+        if (this.scope === DEFAULT_SCOPE) {
+            return this.name;
+        } else {
+            return `${this.scope}.${this.collection}.${this.name}`;
+        }
+    }
 
     constructor(public definition: IndexDefinition, name?: string) {
         this.definition = definition;
         this.name = name || definition.name;
         this.phase = 1;
+
+        this.scope = DEFAULT_SCOPE;
+        this.collection = DEFAULT_COLLECTION;
     }
 
     abstract execute(indexManager: IndexManager, logger: Logger): Promise<void>;

--- a/app/plan/move-index-mutation.ts
+++ b/app/plan/move-index-mutation.ts
@@ -32,7 +32,7 @@ export class MoveIndexMutation extends IndexMutation {
             chalk.cyanBright;
 
         logger.info(color(
-            `  Move: ${this.name}`));
+            `  Move: ${this.displayName}`));
 
         logger.info(color(
             ` Nodes: ${this.nodes.join()}`));

--- a/app/plan/resize-index-mutation.ts
+++ b/app/plan/resize-index-mutation.ts
@@ -17,7 +17,7 @@ export class ResizeIndexMutation extends IndexMutation {
         const color = chalk.cyanBright;
 
         logger.info(color(
-            `Resize: ${this.name}`));
+            `Resize: ${this.displayName}`));
 
         logger.info(color(
             `  Repl: ${this.definition.num_replica}`));

--- a/app/plan/update-index-mutation.ts
+++ b/app/plan/update-index-mutation.ts
@@ -22,7 +22,7 @@ export class UpdateIndexMutation extends IndexMutation {
     print(logger: Logger): void {
         logger.info(
             chalk.cyanBright(
-                `Update: ${this.name}`));
+                `Update: ${this.displayName}`));
 
         if (!isEqual(this.existingIndex.index_key, this.definition.index_key)) {
             logger.info(


### PR DESCRIPTION
Motivation
----------
This is a step in the process of supporting scopes/collections, allowing
index planning to take into account scopes/collections.

Modifications
-------------
Include scope/collection in the plan display if non-default.

Group index building by scope/collection.

Include the scope/collection in index drops.