### PR TITLE
Complete basic collection support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,8 +16,8 @@
                 "-p",
                 "password",
                 "sync",
-                "beer-sample",
-                "./example/beer-sample"
+                "travel-sample",
+                "./example/travel-sample"
             ],
             "console": "integratedTerminal",
             "sourceMaps": true,

--- a/app/configuration/index-validation.ts
+++ b/app/configuration/index-validation.ts
@@ -91,6 +91,10 @@ export const IndexValidators: ValidatorSet<IndexConfigurationBase> = {
         }
     },
     post_validate: function(): void {
+        if (!!this.scope !== !!this.collection) {
+            throw new Error('if scope is supplied collection must also be supplied');
+        }
+
         if (!this.is_primary) {
             const isDrop = this.lifecycle && this.lifecycle.drop;
 

--- a/app/configuration/types.ts
+++ b/app/configuration/types.ts
@@ -1,3 +1,6 @@
+import { DEFAULT_COLLECTION, DEFAULT_SCOPE } from "../index-manager";
+import { ensureEscaped } from "../util";
+
 export enum PartitionStrategy {
     Hash = "HASH"
 }
@@ -22,6 +25,8 @@ export type PostProcessHandler = (this: IndexConfigurationBase, require: NodeReq
 
 export interface IndexConfigurationBase {
     name?: string;
+    scope?: string;
+    collection?: string;
     is_primary?: boolean;
     index_key?: string | string[];
     condition?: string;
@@ -59,4 +64,10 @@ export function isOverride(item: ConfigurationItem): item is OverrideConfigurati
 
 export function isNodeMap(item: ConfigurationItem): item is NodeMapConfiguration {
     return item.type === ConfigurationType.NodeMap;
+}
+
+export function isSameIndex(a: IndexConfigurationBase, b: IndexConfigurationBase): boolean {
+    return (a.scope ?? DEFAULT_SCOPE) === (b.scope ?? DEFAULT_SCOPE) &&
+        (a.collection ?? DEFAULT_COLLECTION) === (b.collection ?? DEFAULT_COLLECTION) &&
+        ensureEscaped(a.name) === ensureEscaped(b.name);
 }

--- a/app/definition/index-definition-base.ts
+++ b/app/definition/index-definition-base.ts
@@ -1,8 +1,11 @@
 import { isString } from 'lodash';
 import { IndexConfiguration } from '../configuration';
+import { DEFAULT_COLLECTION, DEFAULT_SCOPE } from '../index-manager';
 
 export abstract class IndexDefinitionBase {
-    name: string;
+    readonly name: string;
+    readonly scope: string;
+    readonly collection: string;
 
     constructor(configuration: IndexConfiguration) {
         if (!configuration.name || !isString(configuration.name)) {
@@ -10,5 +13,7 @@ export abstract class IndexDefinitionBase {
         }
 
         this.name = configuration.name;
+        this.scope = configuration.scope ?? DEFAULT_SCOPE;
+        this.collection = configuration.collection ?? DEFAULT_COLLECTION;
     }
 }

--- a/app/plan/index-mutation.ts
+++ b/app/plan/index-mutation.ts
@@ -1,5 +1,5 @@
 import { IndexDefinition } from "../definition";
-import { DEFAULT_COLLECTION, DEFAULT_SCOPE, IndexManager } from "../index-manager";
+import { DEFAULT_SCOPE, IndexManager } from "../index-manager";
 import { Logger } from "../options";
 
 /**

--- a/app/plan/index-mutation.ts
+++ b/app/plan/index-mutation.ts
@@ -25,10 +25,9 @@ export abstract class IndexMutation {
     constructor(public definition: IndexDefinition, name?: string) {
         this.definition = definition;
         this.name = name || definition.name;
+        this.scope = definition.scope;
+        this.collection = definition.collection;
         this.phase = 1;
-
-        this.scope = DEFAULT_SCOPE;
-        this.collection = DEFAULT_COLLECTION;
     }
 
     abstract execute(indexManager: IndexManager, logger: Logger): Promise<void>;

--- a/app/util.ts
+++ b/app/util.ts
@@ -1,7 +1,16 @@
+import { isNil } from "lodash";
+
 /**
  * Ensures that the N1QL identifier is escaped with backticks
  */
-export function ensureEscaped(identifier: string): string {
+export function ensureEscaped(identifier: string): string;
+export function ensureEscaped(identifier: null | undefined): null | undefined;
+export function ensureEscaped(identifier: string | null | undefined): string | null | undefined;
+export function ensureEscaped(identifier: string | null | undefined): string | null | undefined {
+    if (isNil(identifier)) {
+        return identifier;
+    }
+
     if (!identifier.startsWith('`')) {
         return '`' + identifier.replace(/`/g, '``') + '`';
     } else {

--- a/example/travel-sample/default.yaml
+++ b/example/travel-sample/default.yaml
@@ -9,3 +9,15 @@ name: def_name_type
 index_key:
 - name
 condition: _type = 'User'
+---
+name: def_inventory_hotel_url
+scope: inventory
+collection: hotel
+index_key:
+- url
+---
+name: def_inventory_route_stops
+scope: inventory
+collection: route
+index_key:
+- stops


### PR DESCRIPTION
Motivation
----------
Manage indexes on scopes/collections.

Modifications
-------------
Allow indexes to define scope and collection attributes, and use these
when comparing to existing indexes and creating/updating/dropping
indexes

Results
-------
Basic scope/collection support is in place. However, replica management
with resizing and moving is not yet supported.