### PR TITLE
Remove support for old Couchbase versions

### DIFF
--- a/app/definition/index-definition.spec.ts
+++ b/app/definition/index-definition.spec.ts
@@ -860,41 +860,7 @@ describe('getMutation automatic replica node changes', function() {
             .to.be.instanceof(MoveIndexMutation)
             .and.to.include({
                 name: 'test',
-                phase: 1,
-                unsupported: false,
-            });
-    });
-
-    it('returns unsupported for 5.1 cluster', function() {
-        const def = new IndexDefinition({
-            name: 'test',
-            index_key: '`key`',
-            nodes: ['a', 'b'],
-        });
-
-        const mutations = [...def.getMutations({
-            currentIndexes: [
-                {
-                    name: 'test',
-                    index_key: ['`key`'],
-                    nodes: ['a:8091', 'c:8091'],
-                    num_replica: 1,
-                },
-            ].map(fakeIndex),
-            clusterVersion: {
-                major: 5,
-                minor: 1,
-            },
-        })];
-
-        expect(mutations)
-            .to.have.length(1);
-        expect(mutations[0])
-            .to.be.instanceof(MoveIndexMutation)
-            .and.to.include({
-                name: 'test',
-                phase: 1,
-                unsupported: true,
+                phase: 1
             });
     });
 

--- a/app/definition/index-definition.ts
+++ b/app/definition/index-definition.ts
@@ -257,8 +257,7 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
                 }
             } else {
                 if (!_.isEqual(this.nodes, currentIndex.nodes)) {
-                    yield new MoveIndexMutation(this, this.name + suffix,
-                        !FeatureVersions.alterIndex(context.clusterVersion));
+                    yield new MoveIndexMutation(this, this.name + suffix);
                 }
             }
         }

--- a/app/feature-versions.ts
+++ b/app/feature-versions.ts
@@ -1,5 +1,3 @@
-import { PartitionStrategy } from "./configuration";
-
 export interface Version {
     major: number;
     minor: number;
@@ -11,40 +9,11 @@ export interface Version {
  */
 export class FeatureVersions {
     /**
-     * Tests for ALTER INDEX compatibility
-     */
-    static alterIndex(version: Version | null | undefined): boolean {
-        return !!version &&
-            (version.major > 5 ||
-            (version.major == 5 && version.minor >= 5));
-    }
-
-    /**
      * Tests for ALTER INDEX replica_count compatibility
      */
     static alterIndexReplicaCount(version: Version | null | undefined): boolean {
         return !!version &&
             (version.major > 6 ||
             (version.major == 6 && version.minor >= 5));
-    }
-
-    /**
-     * Tests for PARTITION BY compatibility
-     */
-    static partitionBy(version: Version | null | undefined, strategy: string): boolean {
-        if (strategy.toUpperCase() !== PartitionStrategy.Hash) {
-            return false;
-        }
-
-        return !!version &&
-            (version.major > 5 ||
-            (version.major == 5 && version.minor >= 5));
-    }
-
-    /**
-     * Tests for automatic replica compatibility
-     */
-    static autoReplicas(version: Version | null | undefined): boolean {
-        return !!version && version.major >= 5;
     }
 }

--- a/app/plan/move-index-mutation.ts
+++ b/app/plan/move-index-mutation.ts
@@ -10,13 +10,7 @@ import { Logger } from '../options';
 export class MoveIndexMutation extends IndexMutation {
     private nodes: string[];
 
-    /**
-     * @param {IndexDefinition} definition Index definition
-     * @param {string} name Name of the index to mutate
-     * @param {boolean} unsupported
-     *     If true, don't actually perform this mutation
-     */
-    constructor(definition: IndexDefinition, name: string, private unsupported: boolean) {
+    constructor(definition: IndexDefinition, name: string) {
         super(definition, name);
 
         if (!definition.nodes) {
@@ -27,26 +21,14 @@ export class MoveIndexMutation extends IndexMutation {
     }
 
     print(logger: Logger): void {
-        const color = this.unsupported ?
-            chalk.yellowBright :
-            chalk.cyanBright;
-
-        logger.info(color(
+        logger.info(chalk.cyanBright(
             `  Move: ${this.displayName}`));
 
-        logger.info(color(
+        logger.info(chalk.cyanBright(
             ` Nodes: ${this.nodes.join()}`));
-
-        if (this.unsupported) {
-            logger.info(color(
-                `  Skip: ALTER INDEX is not supported until CB 5.5`
-            ));
-        }
     }
 
     async execute(manager: IndexManager): Promise<void> {
-        if (!this.unsupported) {
-            await manager.moveIndex(this.name, this.scope, this.collection, this.nodes);
-        }
+        await manager.moveIndex(this.name, this.scope, this.collection, this.nodes);
     }
 }

--- a/app/sync.ts
+++ b/app/sync.ts
@@ -1,9 +1,7 @@
 import chalk from 'chalk';
 import { prompt } from 'inquirer';
 import { compact, extend, flatten, isArrayLike } from 'lodash';
-import { PartitionStrategy } from './configuration';
 import { DefinitionLoader } from './definition';
-import { FeatureVersions } from './feature-versions';
 import { IndexManager } from './index-manager';
 import { SyncOptions } from './options';
 import { Plan } from './plan';
@@ -75,25 +73,8 @@ export class Sync {
             clusterVersion: await this.manager.getClusterVersion(),
         };
 
-        if (!FeatureVersions.autoReplicas(mutationContext.clusterVersion)) {
-            // Force all definitions to use manual replica management
-            definitions.forEach((def) => {
-                def.manual_replica = true;
-            });
-        }
-
         // Normalize the definitions before testing for mutations
         for (const def of definitions) {
-            if (def.partition) {
-                const strategy = def.partition.strategy || PartitionStrategy.Hash;
-
-                if (!FeatureVersions.partitionBy(
-                    mutationContext.clusterVersion, strategy)) {
-                    throw new Error(
-                        `Partition strategy '${strategy}' is not supported`);
-                }
-            }
-
             await def.normalize(this.manager);
         }
 

--- a/app/validator.ts
+++ b/app/validator.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import { extend, isArrayLike } from 'lodash';
 import { DefinitionLoader, IndexDefinition, NodeMap } from './definition';
-import { FeatureVersions } from './feature-versions';
 import { IndexManager } from './index-manager';
 import { ValidateOptions } from './options';
 
@@ -37,15 +36,6 @@ export class Validator {
      * Uses EXPLAIN to validate syntax of the CREATE INDEX statement.
      */
     private async validateSyntax(manager: IndexManager, definitions: IndexDefinition[], nodeMap: NodeMap) {
-        const clusterVersion = await manager.getClusterVersion();
-
-        if (!FeatureVersions.autoReplicas(clusterVersion)) {
-            // Force all definitions to use manual replica management
-            definitions.forEach((def) => {
-                def.manual_replica = true;
-            });
-        }
-
         nodeMap.apply(definitions);
 
         for (const definition of definitions) {


### PR DESCRIPTION
Motivation
----------
Couchbase 5.5 is pretty old at this point, so the added complexity of
supporting 4.x and 5.0 isn't very valuable.

Modifications
-------------
Remove special controls in place to support older versions of Couchbase.

- Automatic replica management is now always supported
- Moving index replicas with automatic replica management is now always
  supported
- Partitioned indexes are now always supported
- RBAC is always used for authentication (this was done in a previous
  change)