### PR TITLE
Run all index mutation queries as adhoc

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,9 +27,9 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   node1:
-    image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+    image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     labels:
-      com.centeredgesoftware.cbindexmgr.image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+      com.centeredgesoftware.cbindexmgr.image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     command: >
       /bin/bash -c "
       set -m;
@@ -51,9 +51,9 @@ services:
       fi;
       fg 1"
   node2:
-    image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+    image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     labels:
-      com.centeredgesoftware.cbindexmgr.image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+      com.centeredgesoftware.cbindexmgr.image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     command: >
       /bin/bash -c "
       set -m;
@@ -69,9 +69,9 @@ services:
       fi;
       fg 1"
   node3:
-    image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+    image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     labels:
-      com.centeredgesoftware.cbindexmgr.image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+      com.centeredgesoftware.cbindexmgr.image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     command: >
       /bin/bash -c "
       set -m;
@@ -87,7 +87,7 @@ services:
       fi;
       fg 1"
   startup:
-    image: ${CBIMAGE:-couchbase:enterprise-7.0.0}
+    image: ${CBIMAGE:-couchbase:enterprise-7.1.1}
     depends_on:
       - node1
       - node2

--- a/packages/couchbase-index-manager/app/index-manager.ts
+++ b/packages/couchbase-index-manager/app/index-manager.ts
@@ -254,7 +254,7 @@ export class IndexManager {
      * Creates an index based on an index definition
      */
     async createIndex(statement: string): Promise<void> {
-        await this.cluster.query(statement);
+        await this.cluster.query(statement, {adhoc: true});
     }
 
     private getAlterStatement(indexName: string, scope: string, collection: string, withClause: WithClause): string {
@@ -283,7 +283,7 @@ export class IndexManager {
 
         const statement = this.getAlterStatement(indexName, scope, collection, withClause);
 
-        await this.cluster.query(statement);
+        await this.cluster.query(statement, {adhoc: true});
     }
 
     /**
@@ -300,8 +300,8 @@ export class IndexManager {
         }
 
         const statement = this.getAlterStatement(indexName, scope, collection, withClause);
-
-        await this.cluster.query(statement);
+        console.log(statement);
+        await this.cluster.query(statement, {adhoc: true});
     }
 
     /**
@@ -404,7 +404,8 @@ export class IndexManager {
 
             // Run our deferred build query
             await this.cluster.query(qs, {
-                timeout: options?.timeout
+                timeout: options?.timeout,
+                adhoc: true
             });
         }
     }


### PR DESCRIPTION
Motivation
------------
There seems to be a bug around index resizing and prepared queries,
https://issues.couchbase.com/browse/MB-53264, this prevents that issue and
possibly other unexpected issues. It should also be slightly
more performant by avoiding an unused prepare, since every
query is different.

Note that this is only required until 4.1.2 of the SDK fixes this bug:
https://issues.couchbase.com/browse/JSCBC-1092

Modifications
---------------
- Send all index mutations with adhoc of true.
- Update to Server 7.1.1 for local testing