### PR TITLE
Use new method to get HttpExecutor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14958,7 +14958,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^2.3.1",
-        "couchbase": "^4.1.1",
+        "couchbase": "^4.2.8",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.15",
         "tslib": "^2.6.2"
@@ -20453,7 +20453,7 @@
         "@typescript-eslint/parser": "^6.12.0",
         "babel-jest": "^27.2.5",
         "chalk": "^2.3.1",
-        "couchbase": "^4.1.1",
+        "couchbase": "^4.2.8",
         "eslint": "^8.54.0",
         "eslint-plugin-jest": "^24.4.0",
         "eslint-plugin-node": "^11.1.0",

--- a/packages/couchbase-index-manager/package.json
+++ b/packages/couchbase-index-manager/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "chalk": "^2.3.1",
-    "couchbase": "^4.1.1",
+    "couchbase": "^4.2.8",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.15",
     "tslib": "^2.6.2"


### PR DESCRIPTION
Motivation
------------
The latest Couchbase SDK is getting errors where we were accessing an
internal member to make HTTP requests.

Modifications
---------------
Use the new surface that is a bit less hacky, though still involves accessing an
unexported file from the SDK.

Fixes #118