### PR TITLE
Allow num_replica to be undefined

### DIFF
--- a/packages/couchbase-index-manager/app/definition/index-definition.ts
+++ b/packages/couchbase-index-manager/app/definition/index-definition.ts
@@ -83,8 +83,12 @@ const keys: KeyProcessorSet = {
     },
     manual_replica: (val: any) => !!val,
     num_replica: function(this: IndexDefinition, val: any) {
+        if (_.isUndefined(val)) {
+            return val;
+        }
+
         if (!this.partition) {
-            return val as number ?? (this.nodes ? this.nodes.length-1 : undefined);
+            return val as number ?? (this.nodes ? this.nodes.length-1 : 0);
         } else {
             // for partitioned index, num_replica and nodes
             // are decoupled so skip nodes check
@@ -478,8 +482,9 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
 
             const newNodeList: string[] = [];
             const unused = _.clone(this.nodes);
+            const num_replica = this.num_replica ?? 0; // Default to 0 if undefined
 
-            for (let replicaNum=0; replicaNum<=this.num_replica; replicaNum++) {
+            for (let replicaNum=0; replicaNum<=num_replica; replicaNum++) {
                 const suffix = !replicaNum ?
                     '' :
                     `_replica${replicaNum}`;
@@ -500,7 +505,7 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
             }
 
             // Fill in the remaining nodes that didn't have a match
-            for (let replicaNum=0; replicaNum<=this.num_replica; replicaNum++) {
+            for (let replicaNum=0; replicaNum<=num_replica; replicaNum++) {
                 if (!newNodeList[replicaNum]) {
                     const nextUnused = unused.shift();
                     if (!nextUnused) {

--- a/packages/couchbase-index-manager/app/definition/index-definition.ts
+++ b/packages/couchbase-index-manager/app/definition/index-definition.ts
@@ -84,11 +84,11 @@ const keys: KeyProcessorSet = {
     manual_replica: (val: any) => !!val,
     num_replica: function(this: IndexDefinition, val: any) {
         if (!this.partition) {
-            return val as number ?? (this.nodes ? this.nodes.length-1 : 0);
+            return val as number ?? (this.nodes ? this.nodes.length-1 : undefined);
         } else {
             // for partitioned index, num_replica and nodes
             // are decoupled so skip nodes check
-            return val as number ?? 0;
+            return val as number;
         }
     },
     retain_deleted_xattr: (val: any) => !!val,
@@ -128,7 +128,7 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
     condition?: string;
     partition?: Partition;
     manual_replica: boolean;
-    num_replica: number;
+    num_replica?: number;
     nodes?: string[];
     retain_deleted_xattr: boolean;
     lifecycle?: Lifecycle;
@@ -178,13 +178,14 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
         if (!this.manual_replica) {
             mutations.push(...this.getMutation(context));
         } else {
-            for (let i=0; i<=this.num_replica; i++) {
+            const num_replica = this.num_replica ?? 0; // Default to 0 if undefined
+            for (let i=0; i<=num_replica; i++) {
                 mutations.push(...this.getMutation(context, i));
             }
 
             if (!this.is_primary) {
                 // Handle dropping replicas if the count is lowered
-                for (let i=this.num_replica+1; i<=10; i++) {
+                for (let i=num_replica+1; i<=10; i++) {
                     mutations.push(...this.getMutation(
                         context, i, true));
                 }
@@ -220,6 +221,7 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
                 this.getWithClause(context, replicaNum),
                 currentIndex);
         } else if (!this.manual_replica &&
+            !_.isUndefined(this.num_replica) && 
             !_.isUndefined(currentIndex.num_replica) &&
             this.num_replica !== currentIndex.num_replica) {
             // Number of replicas changed for an auto replica index
@@ -257,7 +259,7 @@ export class IndexDefinition extends IndexDefinitionBase implements IndexConfigu
             withClause = {
                 nodes: this.nodes ? this.nodes.map(p => ensurePort(p, context.isSecure)) : undefined,
                 num_replica: this.num_replica,
-            };
+                };
         } else {
             withClause = {
                 nodes: this.nodes && [ensurePort(this.nodes[replicaNum ?? 0], context.isSecure)],

--- a/packages/couchbase-index-manager/app/plan/create-index-mutation.ts
+++ b/packages/couchbase-index-manager/app/plan/create-index-mutation.ts
@@ -47,7 +47,7 @@ export class CreateIndexMutation extends IndexMutation {
             }
         }
 
-        if (this.definition.num_replica > 0 &&
+        if ((this.definition.num_replica ?? 0) > 0 &&
             !this.definition.manual_replica) {
             logger.info(
                 chalk.greenBright(

--- a/packages/couchbase-index-manager/app/plan/resize-index-mutation.ts
+++ b/packages/couchbase-index-manager/app/plan/resize-index-mutation.ts
@@ -29,6 +29,6 @@ export class ResizeIndexMutation extends IndexMutation {
     }
 
     async execute(manager: IndexManager): Promise<void> {
-        await manager.resizeIndex(this.name, this.scope, this.collection, this.definition.num_replica, this.definition.nodes);
+        await manager.resizeIndex(this.name, this.scope, this.collection, this.definition.num_replica ?? 0, this.definition.nodes);
     }
 }

--- a/packages/couchbase-index-manager/app/plan/update-index-mutation.ts
+++ b/packages/couchbase-index-manager/app/plan/update-index-mutation.ts
@@ -63,7 +63,7 @@ export class UpdateIndexMutation extends IndexMutation {
                     `     -> ${this.definition.condition || 'none'}`));
         }
 
-        const hasReplica = Math.max(this.definition.num_replica,
+        const hasReplica = Math.max(this.definition.num_replica ?? 0,
                                     this.existingIndex.num_replica) > 0;
         if (!this.definition.manual_replica && hasReplica) {
             logger.info(
@@ -110,6 +110,6 @@ export class UpdateIndexMutation extends IndexMutation {
         // Safe if there are multiple replicas
         // As each update will run in its own phase
         return this.definition.manual_replica &&
-            this.definition.num_replica > 0;
+            (this.definition.num_replica ?? 0) > 0;
     }
 }


### PR DESCRIPTION
Motivation
----------
Capella defaults num_replica to 1 while Couchbase Server defaults to 0.
Allowing num_replica to be undefined allows the user to use the default
for their environment.

Modifications
-------------
Allow num_replica to be undefined and don't send in the index create
or update query if it is undefined. Don't consider num_replica when
resizing existing indices if it is undefined.

Results
-------
We are now more compatible with Capella behaviors. However, there is
still one remaining issue. Capella will ignore num_replica = 0 on
create and still create an index with one replica, causing the next
sync to resize to zero replicas. However, num_replica = undefined will
now behave consistently.